### PR TITLE
feat: fly.io health check, .dockerignore, fix DEBUG_MODE test failures

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+.venv/
+.uv/
+__pycache__/
+*.egg-info/
+dist/
+build/
+.git/
+tests/
+.env
+.env~
+..env.un~
+*.pyc

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -69,5 +69,7 @@ the closest option: `sea`, `lax`, `iad`, `ewr`, `lhr`, `fra`, etc.
 ## Cost
 
 With `min_machines_running = 0` the machine stops when idle and restarts
-on the next request. This keeps usage within Fly's free tier for a
-personal tool.
+on the next request. You pay only for active compute time, which is very
+low for a personal tool with infrequent use. Fly.io no longer has a free
+tier, but a shared-cpu-1x machine costs roughly $0.0000022/second when
+running.

--- a/fly.toml
+++ b/fly.toml
@@ -12,14 +12,21 @@ primary_region = "ord"          # Chicago — pick closest: sea, lax, iad, ewr, 
 [http_service]
   internal_port = 8080
   force_https = true
-  auto_stop_machines = "stop"   # free tier: stop when idle
+  auto_stop_machines = "stop"   # stop when idle (pay only when in use)
   auto_start_machines = true
-  min_machines_running = 0      # 0 = fully free when idle
+  min_machines_running = 0      # 0 = stopped when idle
 
   [http_service.concurrency]
     type = "connections"
     hard_limit = 25
     soft_limit = 20
+
+  [[http_service.checks]]
+    interval = "15s"
+    timeout = "5s"
+    grace_period = "10s"
+    method = "GET"
+    path = "/health"
 
 [[vm]]
   size = "shared-cpu-1x"

--- a/src/planning_agent/main_web.py
+++ b/src/planning_agent/main_web.py
@@ -9,7 +9,7 @@ import uuid
 from pathlib import Path
 
 from fastapi import Depends, FastAPI, Request, Response, WebSocket, WebSocketDisconnect
-from fastapi.responses import HTMLResponse, RedirectResponse
+from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
 
 from .agent import ConfirmFn, DebugFn, create_agent
 from .config import DEBUG_MODE
@@ -35,6 +35,15 @@ logger = logging.getLogger("planning-agent")
 _STATIC = Path(__file__).parent / "static"
 
 app = FastAPI(title="Planning Agent")
+
+
+# ---------------------------------------------------------------------------
+# Health check (no auth required)
+# ---------------------------------------------------------------------------
+
+@app.get("/health")
+async def health() -> JSONResponse:
+    return JSONResponse({"status": "ok"})
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -97,6 +97,7 @@ class TestWebSocketChat:
                 "planning_agent.auth.WEB_SECRET",
                 _TEST_SECRET,
             ),
+            patch("planning_agent.main_web.DEBUG_MODE", False),
             patch(
                 "planning_agent.main_web.create_agent",
                 return_value=mock_agent,
@@ -170,6 +171,7 @@ class TestWebSocketChat:
                 "planning_agent.auth.WEB_SECRET",
                 _TEST_SECRET,
             ),
+            patch("planning_agent.main_web.DEBUG_MODE", False),
             patch(
                 "planning_agent.main_web.create_agent",
                 return_value=mock_agent,
@@ -241,6 +243,7 @@ class TestWebSocketConfirm:
                 "planning_agent.auth.WEB_SECRET",
                 _TEST_SECRET,
             ),
+            patch("planning_agent.main_web.DEBUG_MODE", False),
             patch(
                 "planning_agent.main_web.create_agent",
                 side_effect=capture_create_agent,
@@ -309,6 +312,7 @@ class TestWebSocketConfirm:
                 "planning_agent.auth.WEB_SECRET",
                 _TEST_SECRET,
             ),
+            patch("planning_agent.main_web.DEBUG_MODE", False),
             patch(
                 "planning_agent.main_web.create_agent",
                 side_effect=capture_create_agent,


### PR DESCRIPTION
## Summary

- Adds `GET /health` endpoint (no auth) so fly.io health checks have a clean target
- Adds `[[http_service.checks]]` block in `fly.toml` pointing at `/health`
- Adds `.dockerignore` — keeps build context lean, prevents `.env` from leaking into the image
- Fixes stale "free tier" wording in `fly.toml` and `DEPLOY.md`
- Patches `DEBUG_MODE=False` in 4 WebSocket tests that were failing when `DEBUG_MODE` is set in local `.env`