### PR TITLE
M4: Nightly replan job

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -25,3 +25,18 @@ framework switch (e.g. to Anthropic Agent SDK).
 **Trade-off:** Logfire's eval tooling may be less mature than
 Langfuse's. If eval needs outgrow it, evals can use a separate
 tool while Logfire handles tracing.
+
+## Nightly replan host
+
+**Decision:** Run nightly replan via an authenticated
+`POST /internal/nightly-replan` endpoint on the existing web app
+Machine, triggered by a minimal Fly scheduled Machine that curls it
+with a bearer token (#54).
+
+**Rationale:** The replan logic touches `/data` (planning-agent state),
+and Fly volumes attach to one Machine at a time, so a standalone
+scheduled Machine that runs the full job would need its own copy of the
+volume. Keeping the logic on the web Machine and using the scheduler as
+a dumb cron-curl avoids that, keeps secrets in one place, and lets the
+endpoint double as a manual ad-hoc trigger. Local cron / Task Scheduler
+was rejected because it requires the laptop to be on at midnight.

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -100,6 +100,66 @@ DEBUG_MODE=1 uv run planning-agent-web
 flyctl secrets set DEBUG_MODE=1
 ```
 
+## Nightly replan (scheduled Machine)
+
+The nightly replan job runs as a `POST /internal/nightly-replan`
+endpoint on the web Machine, triggered by a separate Fly scheduled
+Machine that curls it with a bearer token. This avoids needing a
+second copy of the `/data` volume (Fly volumes attach to one Machine
+at a time).
+
+### 1. Set the shared bearer token
+
+```bash
+flyctl secrets set \
+  NIGHTLY_REPLAN_TOKEN="$(openssl rand -hex 32)" \
+  -a planning-agent
+```
+
+When `NIGHTLY_REPLAN_TOKEN` is unset the endpoint returns 503, so
+nothing fires by accident.
+
+### 2. Manual ad-hoc trigger
+
+```bash
+TOKEN=$(flyctl secrets list -a planning-agent | grep NIGHTLY)  # confirm set
+# Dry-run from your laptop:
+curl -X POST \
+  -H "Authorization: Bearer $NIGHTLY_REPLAN_TOKEN" \
+  "https://planning-agent.fly.dev/internal/nightly-replan?dry_run=true"
+
+# Real run:
+curl -X POST \
+  -H "Authorization: Bearer $NIGHTLY_REPLAN_TOKEN" \
+  https://planning-agent.fly.dev/internal/nightly-replan
+```
+
+### 3. Scheduled Machine
+
+Run a tiny Alpine Machine on a schedule (no volume, no app code):
+
+```bash
+flyctl machine run \
+  --schedule daily \
+  --region ord \
+  --name nightly-replan-cron \
+  --env "NIGHTLY_URL=https://planning-agent.fly.dev/internal/nightly-replan" \
+  --env "NIGHTLY_REPLAN_TOKEN=<paste the token here>" \
+  alpine/curl:latest \
+  -a planning-agent \
+  -- sh -c 'curl -fsS -X POST -H "Authorization: Bearer $NIGHTLY_REPLAN_TOKEN" "$NIGHTLY_URL"'
+```
+
+`--schedule daily` runs once every 24 hours (Fly picks the time).
+Use `--schedule hourly` to test, then update.
+
+Verify the schedule:
+
+```bash
+flyctl machine list -a planning-agent
+flyctl logs -a planning-agent -i <machine-id>
+```
+
 ## Regions
 
 The `fly.toml` defaults to `ord` (Chicago). Change `primary_region` to

--- a/MILESTONES.md
+++ b/MILESTONES.md
@@ -124,6 +124,8 @@ from today and earlier, and spreads them forward using the existing
 - [x] Add `planning-agent-nightly` entry point in `pyproject.toml`. (#17)
 - [x] Add unit tests with a mocked Todoist API. (#18)
 - [x] Document cron / Task Scheduler setup in `README.md`. (#19)
+- [ ] Nightly replan via authenticated endpoint + Fly scheduled Machine
+  (replaces local cron docs). (#54)
 
 
 ## Milestone 5: Fuzzy Recurring Tasks — `planned`

--- a/MILESTONES.md
+++ b/MILESTONES.md
@@ -114,16 +114,16 @@ from today and earlier, and spreads them forward using the existing
 - A cron/Task Scheduler example is documented.
 
 **Tasks:**
-- [ ] Create `src/planning_agent/main_nightly.py`: async entry point that
+- [x] Create `src/planning_agent/main_nightly.py`: async entry point that
   identifies overdue open tasks and uses `todoist_scheduler` spreading
   logic to assign new due dates. (#14)
-- [ ] Add `--dry-run` CLI flag; print planned changes without calling the
+- [x] Add `--dry-run` CLI flag; print planned changes without calling the
   Todoist API. (#15)
-- [ ] Add idempotency guard: skip tasks already rescheduled to today or
+- [x] Add idempotency guard: skip tasks already rescheduled to today or
   later. (#16)
-- [ ] Add `planning-agent-nightly` entry point in `pyproject.toml`. (#17)
-- [ ] Add unit tests with a mocked Todoist API. (#18)
-- [ ] Document cron / Task Scheduler setup in `README.md`. (#19)
+- [x] Add `planning-agent-nightly` entry point in `pyproject.toml`. (#17)
+- [x] Add unit tests with a mocked Todoist API. (#18)
+- [x] Document cron / Task Scheduler setup in `README.md`. (#19)
 
 
 ## Milestone 5: Fuzzy Recurring Tasks — `planned`

--- a/MILESTONES.md
+++ b/MILESTONES.md
@@ -124,7 +124,7 @@ from today and earlier, and spreads them forward using the existing
 - [x] Add `planning-agent-nightly` entry point in `pyproject.toml`. (#17)
 - [x] Add unit tests with a mocked Todoist API. (#18)
 - [x] Document cron / Task Scheduler setup in `README.md`. (#19)
-- [ ] Nightly replan via authenticated endpoint + Fly scheduled Machine
+- [x] Nightly replan via authenticated endpoint + Fly scheduled Machine
   (replaces local cron docs). (#54)
 
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,11 @@ uv run planning-agent
 
 # Planning agent — web (http://localhost:8080)
 uv run planning-agent-web
+
+# Nightly replan — reschedule overdue tasks forward
+uv run planning-agent-nightly
+uv run planning-agent-nightly --dry-run   # preview only
+uv run planning-agent-nightly -v          # verbose
 ```
 
 ## Web Interface
@@ -78,3 +83,28 @@ The server accepts connections at `GET /` (HTML UI) and
 `WebSocket /ws` (chat protocol). Tool confirmations appear
 as inline Yes/No prompts in the UI; no server restart
 needed.
+
+## Nightly Replan Job
+
+`planning-agent-nightly` finds overdue Todoist tasks and
+spreads them across upcoming days, respecting the
+5-tasks-per-day limit. Recurring tasks preserve their
+recurrence rules. The job is idempotent — safe to run
+multiple times.
+
+### Scheduling with cron (Linux/macOS/WSL)
+
+```cron
+# Run at 11:55 PM daily
+55 23 * * * cd /path/to/planning-agent && uv run planning-agent-nightly >> /var/log/planning-agent-nightly.log 2>&1
+```
+
+### Scheduling with Task Scheduler (Windows)
+
+1. Open Task Scheduler
+2. Create Basic Task: "Planning Agent Nightly"
+3. Trigger: Daily at 11:55 PM
+4. Action: Start a program
+   - Program: `uv`
+   - Arguments: `run planning-agent-nightly`
+   - Start in: `C:\path\to\planning-agent`

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,31 +1,37 @@
 # Status
 
-**Last updated:** 2026-04-05
-**Active milestone:** Milestone 4 — Nightly Replan Job
+**Last updated:** 2026-04-07
+**Active milestone:** Milestone 4 — Nightly Replan Job (PR open)
 
 ## Recently Completed
 
-- Milestone 3 complete — all 12 tasks done, PR #52 open
-- #50 — Fix agent missing overdue tasks (summary counts + prompt)
-- #51 — Extend planning horizon to two weeks (14-day window)
-- Version label added to chat UI header (git commit hash)
+- M4 implementation: `planning-agent-nightly` CLI with `--dry-run`,
+  idempotency, recurring task support (PR #53)
+- Extracted `fetch_overdue_tasks` helper into
+  `todoist_scheduler/overdue.py`; `Scheduler` gained backward-compat
+  `dry_run` + `planned_moves` tracking
+- 15 new tests in `tests/test_nightly.py`; 211 total passing
+- Milestone 3 merged (PR #52)
+- GCal token refresh fix; Google OAuth published to production
 
 ## In Progress
 
-- **Milestone 4** — Nightly Replan Job (`planned`, not yet started)
+- **Milestone 4** — PR #53 open, awaiting:
+  1. Live test against real Todoist (`--dry-run` then real run)
+  2. Infrastructure setup to run the job nightly (host TBD —
+     local cron, Task Scheduler, or fly.io scheduled machine)
 
 ## Next Up
 
-- Milestone 4 tasks: #14, #15, #16, #17, #18, #19
-- Fix Google Calendar token refresh (see Blockers)
+- Test PR #53 live, then merge
+- Decide nightly run host and stand it up
+- Then start Milestone 5: Fuzzy Recurring Tasks (#20-#25)
 
 ## Blockers / Open Questions
 
-- **Google Calendar disconnected.** OAuth refresh token is expired
-  and there is no way to re-authenticate from the deployed app.
-  The original token was generated locally and copied to the
-  volume. Needs a proper re-auth flow or a way to refresh from
-  the app.
+- Where should the nightly job run? Local cron is simplest but
+  requires the laptop to be on. fly.io scheduled machines are
+  more reliable but need separate process group config.
 
 ## Key Context
 
@@ -36,9 +42,10 @@
   fly.io secret. Dashboard at logfire-us.pydantic.dev/pankok/planning-agent.
   LLM spans are nested under WebSocket `/ws` trace.
 - Branching strategy: one branch + PR per milestone.
-- Branch `milestone-3-eval` has open PR #52 for M3.
 - Debug mode is per-session via the UI toggle; `DEBUG_MODE` env var
   sets the default. Documented in DEPLOY.md.
 - Todoist SDK v3 returns paginated `Iterator[list[T]]` for
   `get_tasks`, `get_projects`, `get_sections`, `get_comments`,
   and `filter_tasks` — always flatten with nested comprehension.
+- `Scheduler.dry_run=True` collects `planned_moves` without calling
+  the API; `dry_run=False` does both. Backward-compatible default.

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,6 +1,6 @@
 # Status
 
-**Last updated:** 2026-04-07
+**Last updated:** 2026-04-07 (session 2)
 **Active milestone:** Milestone 4 — Nightly Replan Job (PR open)
 
 ## Recently Completed
@@ -18,20 +18,18 @@
 
 - **Milestone 4** — PR #53 open, awaiting:
   1. Live test against real Todoist (`--dry-run` then real run)
-  2. Infrastructure setup to run the job nightly (host TBD —
-     local cron, Task Scheduler, or fly.io scheduled machine)
+  2. Implementation of #54: authenticated `/internal/nightly-replan`
+     endpoint + Fly scheduled Machine that curls it nightly
 
 ## Next Up
 
 - Test PR #53 live, then merge
-- Decide nightly run host and stand it up
+- Implement #54 (endpoint + scheduler Machine + README/DEPLOY updates)
 - Then start Milestone 5: Fuzzy Recurring Tasks (#20-#25)
 
 ## Blockers / Open Questions
 
-- Where should the nightly job run? Local cron is simplest but
-  requires the laptop to be on. fly.io scheduled machines are
-  more reliable but need separate process group config.
+- None — nightly host decision resolved (see DECISIONS.md).
 
 ## Key Context
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ todoist-mcp = "todoist_mcp.server:main"
 planning-context = "planning_context.server:main"
 planning-agent = "planning_agent.main_cli:main_sync"
 planning-agent-web = "planning_agent.main_web:main"
+planning-agent-nightly = "planning_agent.main_nightly:main"
 
 [build-system]
 requires = ["hatchling"]

--- a/src/planning_agent/config.py
+++ b/src/planning_agent/config.py
@@ -22,6 +22,9 @@ ALLOWED_GOOGLE_EMAIL = os.environ.get(
 WEB_SECRET = os.environ.get("WEB_SECRET", "")
 DEBUG_MODE = bool(os.environ.get("DEBUG_MODE", ""))
 LOGFIRE_TOKEN = os.environ.get("LOGFIRE_TOKEN", "")
+NIGHTLY_REPLAN_TOKEN = os.environ.get(
+    "NIGHTLY_REPLAN_TOKEN", ""
+)
 BASE_URL = os.environ.get(
     "BASE_URL", "http://localhost:8080"
 ).rstrip("/")

--- a/src/planning_agent/main_nightly.py
+++ b/src/planning_agent/main_nightly.py
@@ -1,0 +1,131 @@
+"""Nightly replan: reschedule overdue tasks forward."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import sys
+from datetime import date, datetime
+from zoneinfo import ZoneInfo
+
+from todoist_api_python.api import TodoistAPI
+
+from planning_agent import config
+from todoist_scheduler.config import (
+    IGNORE_TASK_TAG,
+    TASKS_PER_DAY,
+)
+from todoist_scheduler.overdue import (
+    fetch_overdue_tasks,
+)
+from todoist_scheduler.scheduler import Scheduler
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="planning-agent-nightly",
+        description=(
+            "Reschedule overdue Todoist tasks forward,"
+            " spreading them across upcoming days."
+        ),
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help=(
+            "Print planned changes without writing"
+            " to Todoist."
+        ),
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Enable debug logging.",
+    )
+    return parser
+
+
+async def run_nightly(
+    dry_run: bool = False,
+) -> list[tuple[str, str, date]]:
+    """Run the nightly replan.
+
+    Returns a list of (task_id, content, target_day)
+    for tasks that were (or would be) rescheduled.
+    """
+    if not config.TODOIST_API_KEY:
+        logging.error("TODOIST_API_KEY is not set.")
+        sys.exit(1)
+
+    api = TodoistAPI(config.TODOIST_API_KEY)
+    today = datetime.now(
+        ZoneInfo(config.USER_TZ)
+    ).date()
+
+    logging.info(
+        "Nightly replan starting for %s "
+        "(dry_run=%s)",
+        today,
+        dry_run,
+    )
+
+    overdue = fetch_overdue_tasks(
+        api, today, IGNORE_TASK_TAG,
+    )
+    logging.info(
+        "Found %d overdue task(s).", len(overdue),
+    )
+
+    if not overdue:
+        logging.info("Nothing to reschedule.")
+        return []
+
+    scheduler = Scheduler(
+        api=api,
+        today=today,
+        tasks_per_day=TASKS_PER_DAY,
+        ignore_tag=IGNORE_TASK_TAG,
+        dry_run=dry_run,
+    )
+    scheduler.schedule_and_push_down(overdue)
+
+    for _, content, day in scheduler.planned_moves:
+        logging.info(
+            "Rescheduled '%s' -> %s",
+            content,
+            day,
+        )
+
+    logging.info(
+        "Nightly replan complete: "
+        "%d task(s) moved.",
+        len(scheduler.planned_moves),
+    )
+    return scheduler.planned_moves
+
+
+def main(
+    argv: list[str] | None = None,
+) -> None:
+    """Synchronous CLI entry point."""
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    level = (
+        logging.DEBUG
+        if args.verbose
+        else logging.INFO
+    )
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s %(levelname)s %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+
+    asyncio.run(run_nightly(dry_run=args.dry_run))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/planning_agent/main_web.py
+++ b/src/planning_agent/main_web.py
@@ -23,6 +23,8 @@ from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
 
 from .agent import ConfirmFn, DebugFn, create_agent
 from .config import DEBUG_MODE
+from . import config
+from .main_nightly import run_nightly
 from .auth import (
     build_auth_url,
     check_allowed_email,
@@ -67,6 +69,60 @@ async def health() -> JSONResponse:
     return JSONResponse({
         "status": "ok",
         "version": GIT_COMMIT,
+    })
+
+
+# ---------------------------------------------------------------------------
+# Internal: nightly replan trigger (bearer-token auth)
+# ---------------------------------------------------------------------------
+
+@app.post("/internal/nightly-replan")
+async def internal_nightly_replan(
+    request: Request,
+    dry_run: bool = False,
+) -> JSONResponse:
+    """Trigger the nightly replan job.
+
+    Auth: Bearer token in `Authorization` header, compared
+    against the `NIGHTLY_REPLAN_TOKEN` env var via constant-time
+    comparison. Intended to be called by a Fly scheduled Machine.
+    """
+    import secrets
+
+    expected = config.NIGHTLY_REPLAN_TOKEN
+    if not expected:
+        return JSONResponse(
+            {"error": "nightly replan disabled"},
+            status_code=503,
+        )
+
+    header = request.headers.get("authorization", "")
+    scheme, _, token = header.partition(" ")
+    if scheme.lower() != "bearer" or not secrets.compare_digest(
+        token, expected,
+    ):
+        return JSONResponse(
+            {"error": "unauthorized"}, status_code=401,
+        )
+
+    try:
+        moves = await run_nightly(dry_run=dry_run)
+    except Exception as exc:
+        logger.exception("nightly replan failed")
+        return JSONResponse(
+            {"error": f"{type(exc).__name__}: {exc}"},
+            status_code=500,
+        )
+
+    return JSONResponse({
+        "ok": True,
+        "dry_run": dry_run,
+        "moved": len(moves),
+        "moves": [
+            {"task_id": tid, "content": content,
+             "target_day": day.isoformat()}
+            for tid, content, day in moves
+        ],
     })
 
 

--- a/src/todoist_scheduler/main.py
+++ b/src/todoist_scheduler/main.py
@@ -5,6 +5,7 @@ from zoneinfo import ZoneInfo
 from todoist_api_python.api import TodoistAPI
 
 import todoist_scheduler.config as config
+from todoist_scheduler.overdue import fetch_overdue_tasks
 from todoist_scheduler.scheduler import Scheduler
 
 logging.basicConfig(level=logging.DEBUG)
@@ -22,26 +23,9 @@ def main() -> None:
         ignore_tag=config.IGNORE_TASK_TAG,
     )
 
-    logging.info("Getting overdue tasks...")
-    overdue_tasks = [
-        task
-        for page in api.filter_tasks(
-            query=(
-                "overdue & ! p1"
-                f" & ! @{config.IGNORE_TASK_TAG}"
-            )
-        )
-        for task in page
-    ]
-
-    today_str = today.strftime("%Y-%m-%d")
-    # filter out tasks that are due today because Todoist
-    # has a weird idea about what overdue means
-    overdue_tasks = [
-        t for t in overdue_tasks if
-          t.due is not None and
-          t.due.date != today_str  # pyright: ignore[reportUnknownMemberType]
-    ]
+    overdue_tasks = fetch_overdue_tasks(
+        api, today, config.IGNORE_TASK_TAG,
+    )
 
     scheduler_instance.schedule_and_push_down(overdue_tasks)
 

--- a/src/todoist_scheduler/overdue.py
+++ b/src/todoist_scheduler/overdue.py
@@ -1,0 +1,43 @@
+"""Shared helper to fetch overdue tasks from Todoist."""
+
+from __future__ import annotations
+
+import logging
+from datetime import date
+
+from todoist_api_python.api import TodoistAPI
+from todoist_api_python.models import Task
+
+
+def fetch_overdue_tasks(
+    api: TodoistAPI,
+    today: date,
+    ignore_tag: str,
+) -> list[Task]:
+    """Fetch open overdue tasks, excluding p1 and
+    tasks tagged with *ignore_tag*.
+
+    Filters out tasks due today — Todoist's "overdue"
+    filter includes them, but they are not yet past-due.
+    """
+    logging.info("Getting overdue tasks...")
+    overdue_tasks: list[Task] = [
+        task
+        for page in api.filter_tasks(
+            query=(
+                "overdue & ! p1"
+                f" & ! @{ignore_tag}"
+            )
+        )
+        for task in page
+    ]
+
+    today_str = today.strftime("%Y-%m-%d")
+    # Todoist considers tasks due today as "overdue"
+    return [
+        t for t in overdue_tasks
+        if (
+            t.due is not None
+            and t.due.date != today_str  # pyright: ignore[reportUnknownMemberType]
+        )
+    ]

--- a/src/todoist_scheduler/scheduler.py
+++ b/src/todoist_scheduler/scheduler.py
@@ -17,11 +17,16 @@ class Scheduler:
         today: date,
         tasks_per_day: int,
         ignore_tag: str,
+        dry_run: bool = False,
     ) -> None:
         self.api: TodoistAPI = api
         self.today: date = today
         self.tasks_per_day: int = tasks_per_day
         self.ignore_tag: str = ignore_tag
+        self.dry_run: bool = dry_run
+        self.planned_moves: list[
+            tuple[str, str, date]
+        ] = []
 
     def _sort_tasks(self, tasks: List[Task]) -> None:
         """Sorts tasks by priority (desc) and then due date (asc)."""
@@ -43,6 +48,17 @@ class Scheduler:
 
     def _reschedule_to(self, task: Task, day: date) -> None:
         """Reschedules a task to a new date."""
+        self.planned_moves.append(
+            (task.id, task.content, day)
+        )
+        if self.dry_run:
+            logging.info(
+                "[DRY RUN] Would reschedule '%s' "
+                "to %s",
+                task.content,
+                day,
+            )
+            return
         reschedule_task(self.api, task, day)
 
     def _slice_list(self, lst: List[T], num_items: int) -> Tuple[List[T], List[T]]:

--- a/tests/test_nightly.py
+++ b/tests/test_nightly.py
@@ -1,0 +1,292 @@
+"""Tests for the nightly replan job."""
+
+import asyncio
+import unittest
+from datetime import date, timedelta
+from unittest.mock import MagicMock, patch
+
+from tests.conftest import create_task
+from todoist_scheduler.overdue import fetch_overdue_tasks
+from todoist_scheduler.scheduler import Scheduler
+
+
+class TestFetchOverdueTasks(unittest.TestCase):
+    """Tests for the fetch_overdue_tasks helper."""
+
+    def setUp(self) -> None:
+        self.api = MagicMock()
+        self.today = date(2026, 4, 6)
+        self.ignore_tag = "no_reschedule"
+
+    def test_returns_overdue_tasks(self) -> None:
+        yesterday = (
+            self.today - timedelta(days=1)
+        ).strftime("%Y-%m-%d")
+        task = create_task(
+            "1", "Overdue task",
+            due_date_str=yesterday,
+        )
+        self.api.filter_tasks.return_value = iter(
+            [[task]]
+        )
+
+        result = fetch_overdue_tasks(
+            self.api, self.today, self.ignore_tag,
+        )
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].id, "1")
+
+    def test_excludes_tasks_due_today(self) -> None:
+        today_str = self.today.strftime("%Y-%m-%d")
+        task = create_task(
+            "1", "Due today",
+            due_date_str=today_str,
+        )
+        self.api.filter_tasks.return_value = iter(
+            [[task]]
+        )
+
+        result = fetch_overdue_tasks(
+            self.api, self.today, self.ignore_tag,
+        )
+        self.assertEqual(result, [])
+
+    def test_excludes_tasks_without_due(self) -> None:
+        task = create_task("1", "No due date")
+        self.api.filter_tasks.return_value = iter(
+            [[task]]
+        )
+
+        result = fetch_overdue_tasks(
+            self.api, self.today, self.ignore_tag,
+        )
+        self.assertEqual(result, [])
+
+    def test_empty_result(self) -> None:
+        self.api.filter_tasks.return_value = iter([])
+
+        result = fetch_overdue_tasks(
+            self.api, self.today, self.ignore_tag,
+        )
+        self.assertEqual(result, [])
+
+    def test_filter_query(self) -> None:
+        self.api.filter_tasks.return_value = iter([])
+
+        fetch_overdue_tasks(
+            self.api, self.today, self.ignore_tag,
+        )
+        self.api.filter_tasks.assert_called_once_with(
+            query="overdue & ! p1 & ! @no_reschedule"
+        )
+
+
+class TestSchedulerDryRun(unittest.TestCase):
+    """Tests for the Scheduler dry_run flag."""
+
+    def setUp(self) -> None:
+        self.api = MagicMock()
+        self.api.update_task.return_value = True
+        self.today = date(2026, 4, 6)
+
+    def test_dry_run_collects_moves(self) -> None:
+        scheduler = Scheduler(
+            self.api, self.today, 5,
+            "no_reschedule", dry_run=True,
+        )
+        task = create_task(
+            "1", "Task 1", priority=3,
+            due_date_str="2026-04-04",
+        )
+        self.api.filter_tasks.return_value = iter([])
+
+        scheduler.schedule_and_push_down([task])
+
+        self.assertEqual(len(scheduler.planned_moves), 1)
+        tid, content, day = scheduler.planned_moves[0]
+        self.assertEqual(tid, "1")
+        self.assertEqual(content, "Task 1")
+        self.assertEqual(day, self.today)
+
+    def test_dry_run_skips_api_call(self) -> None:
+        scheduler = Scheduler(
+            self.api, self.today, 5,
+            "no_reschedule", dry_run=True,
+        )
+        task = create_task(
+            "1", "Task 1", priority=3,
+            due_date_str="2026-04-04",
+        )
+        self.api.filter_tasks.return_value = iter([])
+
+        scheduler.schedule_and_push_down([task])
+
+        self.api.update_task.assert_not_called()
+
+    def test_non_dry_run_records_moves(self) -> None:
+        scheduler = Scheduler(
+            self.api, self.today, 5,
+            "no_reschedule", dry_run=False,
+        )
+        task = create_task(
+            "1", "Task 1", priority=3,
+            due_date_str="2026-04-04",
+        )
+        self.api.filter_tasks.return_value = iter([])
+
+        scheduler.schedule_and_push_down([task])
+
+        self.assertEqual(len(scheduler.planned_moves), 1)
+        self.api.update_task.assert_called_once()
+
+
+class TestRunNightly(unittest.TestCase):
+    """Tests for the run_nightly async function."""
+
+    @patch(
+        "planning_agent.main_nightly.TodoistAPI"
+    )
+    @patch("planning_agent.main_nightly.config")
+    def test_dry_run_no_api_write(
+        self,
+        mock_config: MagicMock,
+        mock_api_cls: MagicMock,
+    ) -> None:
+        mock_config.TODOIST_API_KEY = "fake-key"
+        mock_config.USER_TZ = "America/New_York"
+        api = mock_api_cls.return_value
+        api.update_task.return_value = True
+
+        yesterday = (
+            date.today() - timedelta(days=1)
+        ).strftime("%Y-%m-%d")
+        task = create_task(
+            "1", "Overdue",
+            due_date_str=yesterday,
+        )
+        # First call: fetch_overdue_tasks
+        # Second call: _get_tasks_for (inside
+        # schedule_and_push_down)
+        api.filter_tasks.side_effect = [
+            iter([[task]]),
+            iter([]),
+        ]
+
+        from planning_agent.main_nightly import (
+            run_nightly,
+        )
+
+        moves = asyncio.run(run_nightly(dry_run=True))
+
+        self.assertEqual(len(moves), 1)
+        api.update_task.assert_not_called()
+
+    @patch(
+        "planning_agent.main_nightly.TodoistAPI"
+    )
+    @patch("planning_agent.main_nightly.config")
+    def test_no_overdue_is_noop(
+        self,
+        mock_config: MagicMock,
+        mock_api_cls: MagicMock,
+    ) -> None:
+        mock_config.TODOIST_API_KEY = "fake-key"
+        mock_config.USER_TZ = "America/New_York"
+        api = mock_api_cls.return_value
+        api.filter_tasks.return_value = iter([])
+
+        from planning_agent.main_nightly import (
+            run_nightly,
+        )
+
+        moves = asyncio.run(run_nightly(dry_run=False))
+
+        self.assertEqual(moves, [])
+        api.update_task.assert_not_called()
+
+    @patch(
+        "planning_agent.main_nightly.TodoistAPI"
+    )
+    @patch("planning_agent.main_nightly.config")
+    def test_recurring_task_handled(
+        self,
+        mock_config: MagicMock,
+        mock_api_cls: MagicMock,
+    ) -> None:
+        mock_config.TODOIST_API_KEY = "fake-key"
+        mock_config.USER_TZ = "America/New_York"
+        api = mock_api_cls.return_value
+        api.update_task.return_value = True
+
+        yesterday = (
+            date.today() - timedelta(days=1)
+        ).strftime("%Y-%m-%d")
+        task = create_task(
+            "1", "Recurring task",
+            due_date_str=yesterday,
+            is_recurring=True,
+            due_string="every day",
+        )
+        api.filter_tasks.side_effect = [
+            iter([[task]]),
+            iter([]),
+        ]
+
+        from planning_agent.main_nightly import (
+            run_nightly,
+        )
+
+        moves = asyncio.run(run_nightly(dry_run=True))
+
+        self.assertEqual(len(moves), 1)
+
+
+class TestCliParsing(unittest.TestCase):
+    """Tests for CLI argument parsing."""
+
+    def test_dry_run_flag(self) -> None:
+        from planning_agent.main_nightly import (
+            build_parser,
+        )
+
+        parser = build_parser()
+        args = parser.parse_args(["--dry-run"])
+        self.assertTrue(args.dry_run)
+
+    def test_verbose_flag(self) -> None:
+        from planning_agent.main_nightly import (
+            build_parser,
+        )
+
+        parser = build_parser()
+        args = parser.parse_args(["-v"])
+        self.assertTrue(args.verbose)
+
+    def test_defaults(self) -> None:
+        from planning_agent.main_nightly import (
+            build_parser,
+        )
+
+        parser = build_parser()
+        args = parser.parse_args([])
+        self.assertFalse(args.dry_run)
+        self.assertFalse(args.verbose)
+
+    @patch("planning_agent.main_nightly.config")
+    def test_no_api_key_exits(
+        self,
+        mock_config: MagicMock,
+    ) -> None:
+        mock_config.TODOIST_API_KEY = ""
+        mock_config.USER_TZ = "America/New_York"
+
+        from planning_agent.main_nightly import (
+            run_nightly,
+        )
+
+        with self.assertRaises(SystemExit):
+            asyncio.run(run_nightly())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -54,6 +54,115 @@ def _make_mock_context():
     return MagicMock()
 
 
+# ── Internal nightly replan endpoint ──────────────────────
+
+
+class TestInternalNightlyReplan:
+    _PATH = "/internal/nightly-replan"
+    _TOKEN = "test-nightly-token"
+
+    def test_disabled_when_token_unset(self):
+        with patch(
+            "planning_agent.main_web.config.NIGHTLY_REPLAN_TOKEN",
+            "",
+        ):
+            with TestClient(app) as c:
+                r = c.post(self._PATH)
+        assert r.status_code == 503
+
+    def test_missing_auth_header_rejected(self):
+        with patch(
+            "planning_agent.main_web.config.NIGHTLY_REPLAN_TOKEN",
+            self._TOKEN,
+        ):
+            with TestClient(app) as c:
+                r = c.post(self._PATH)
+        assert r.status_code == 401
+
+    def test_wrong_token_rejected(self):
+        with patch(
+            "planning_agent.main_web.config.NIGHTLY_REPLAN_TOKEN",
+            self._TOKEN,
+        ):
+            with TestClient(app) as c:
+                r = c.post(
+                    self._PATH,
+                    headers={"Authorization": "Bearer nope"},
+                )
+        assert r.status_code == 401
+
+    def test_wrong_scheme_rejected(self):
+        with patch(
+            "planning_agent.main_web.config.NIGHTLY_REPLAN_TOKEN",
+            self._TOKEN,
+        ):
+            with TestClient(app) as c:
+                r = c.post(
+                    self._PATH,
+                    headers={
+                        "Authorization": f"Basic {self._TOKEN}",
+                    },
+                )
+        assert r.status_code == 401
+
+    def test_valid_token_runs_nightly(self):
+        from datetime import date
+
+        async def _fake_run(dry_run: bool = False):
+            return [("tid1", "task one", date(2026, 4, 8))]
+
+        with (
+            patch(
+                "planning_agent.main_web.config.NIGHTLY_REPLAN_TOKEN",
+                self._TOKEN,
+            ),
+            patch(
+                "planning_agent.main_web.run_nightly",
+                side_effect=_fake_run,
+            ) as mock_run,
+        ):
+            with TestClient(app) as c:
+                r = c.post(
+                    self._PATH + "?dry_run=true",
+                    headers={
+                        "Authorization": f"Bearer {self._TOKEN}",
+                    },
+                )
+
+        assert r.status_code == 200
+        body = r.json()
+        assert body["ok"] is True
+        assert body["dry_run"] is True
+        assert body["moved"] == 1
+        assert body["moves"][0]["task_id"] == "tid1"
+        assert body["moves"][0]["target_day"] == "2026-04-08"
+        mock_run.assert_called_once_with(dry_run=True)
+
+    def test_run_failure_returns_500(self):
+        async def _boom(dry_run: bool = False):
+            raise RuntimeError("todoist down")
+
+        with (
+            patch(
+                "planning_agent.main_web.config.NIGHTLY_REPLAN_TOKEN",
+                self._TOKEN,
+            ),
+            patch(
+                "planning_agent.main_web.run_nightly",
+                side_effect=_boom,
+            ),
+        ):
+            with TestClient(app) as c:
+                r = c.post(
+                    self._PATH,
+                    headers={
+                        "Authorization": f"Bearer {self._TOKEN}",
+                    },
+                )
+        assert r.status_code == 500
+        assert "todoist down" in r.json()["error"]
+
+
 # ── HTTP routes ────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

Closes Milestone 4 — nightly replan job, end to end.

**CLI (#14–#19):**
- New `planning-agent-nightly` entry point that finds overdue Todoist tasks and spreads them across upcoming days using the existing `todoist_scheduler` spreading logic
- Recurring tasks preserve their patterns (uses `reschedule_task` path)
- `--dry-run` flag previews planned moves without writing
- Idempotent — only fetches truly overdue tasks (due before today), so re-runs are no-ops
- Refactored shared fetch logic into `todoist_scheduler/overdue.py`
- `Scheduler` gains backward-compatible `dry_run` param + `planned_moves` tracking

**Authenticated endpoint + Fly scheduled Machine (#54):**
- New `POST /internal/nightly-replan` on the web app, bearer-token auth via `NIGHTLY_REPLAN_TOKEN` (constant-time compare), supports `?dry_run=true`, returns JSON of moves
- Returns 503 when token unset (so nothing fires by accident), 401 on wrong/missing token, 500 on run failure
- DEPLOY.md documents token setup, manual ad-hoc curl, and `flyctl machine run --schedule daily` for the cron Machine
- Rationale: keeps logic on the Machine that already owns the `/data` volume (Fly volumes attach to one Machine at a time)

## Test plan

- [x] `uv run pytest` — 217 passing (15 new in `test_nightly.py`, 6 new endpoint tests in `test_web.py`)
- [x] `uv run pyright` — clean (only pre-existing google-api stub warnings)
- [x] `uv run planning-agent-nightly --help` works
- [x] Live: `uv run planning-agent-nightly --dry-run` against real Todoist (0 overdue today, exits 0)
- [ ] Live: deploy and curl `/internal/nightly-replan?dry_run=true` against the Fly app
- [ ] Live: create the scheduled Machine via `flyctl machine run --schedule daily ...`

closes #14, closes #15, closes #16, closes #17, closes #18, closes #19, closes #54
