### PR TITLE
Fix recurring-task date shift (#62)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,9 @@ env/
 .env
 project-plans/values.md
 
+# Local scratch (one-off repros, untracked notes — never commit)
+scratch/
+
 # IDE
 .vscode/
 .idea/

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -62,3 +62,26 @@ future scheduled Machine that calls an authenticated endpoint), verify
 that `flyctl machine status -d` shows no token values in the Machine
 env block before considering the work done. Reviewers of scheduled-
 Machine PRs should require this check explicitly.
+
+## Recurring task time placement (#62)
+
+**Decision:** When rescheduling a recurring task with a target time,
+emit `<pattern> at HH:MM starting on YYYY-MM-DD`, not
+`<pattern> starting on YYYY-MM-DD HH:MM`. `compute_due_string` strips
+any pre-existing `at <time>` from the original pattern before
+re-attaching the new time.
+
+**Rationale:** Discovered 2026-04-26 by direct API repro against a
+Todoist test project. The latter format causes Todoist to silently
+ignore the date in `starting on` and snap to the recurrence anchor's
+existing weekday — across `daily`, `every week`, `every! week`,
+`every N weeks`, and `every month`. Putting the time inside the
+pattern makes Todoist honor the requested date. This is independent
+of the `every`/`every!` distinction.
+
+**Defensive partner:** `reschedule_task` now also re-fetches the task
+after `update_task` and raises `DueDateMismatchError` if Todoist
+stored a different date than we asked for. This catches future
+quirks of the same shape and semantic conflicts (e.g. asking to move
+an `every Monday` task to a Tuesday — Todoist snaps back to Monday,
+and we'd otherwise report success on a wrong date).

--- a/src/todoist_scheduler/reschedule.py
+++ b/src/todoist_scheduler/reschedule.py
@@ -23,6 +23,27 @@ def _parse_task_date(task: Task) -> date | None:
     return date.fromisoformat(date_str)
 
 
+# Strips a trailing `at <time>` clause from a Todoist recurrence
+# pattern. Matches "at 5pm", "at 5:30pm", "at 17:00", "at 9am",
+# case-insensitive. See #62 — we re-attach time before
+# `starting on` so Todoist honors the new weekday.
+_AT_TIME_RE = re.compile(
+    r"\s+at\s+\d{1,2}(?::\d{2})?\s*(?:am|pm)?\b",
+    re.IGNORECASE,
+)
+
+
+def _strip_recurrence_pattern(due_string: str) -> str:
+    """Reduce a recurring due_string to just the cadence pattern.
+
+    Removes any trailing `starting on ...` clause and any `at <time>`
+    clause so we can re-emit the pattern with our own time placement.
+    """
+    pattern = re.sub(r'\s*starting on.*', '', due_string)
+    pattern = _AT_TIME_RE.sub('', pattern)
+    return pattern.strip()
+
+
 def compute_due_string(
     task: Task,
     day: date,
@@ -49,30 +70,33 @@ def compute_due_string(
     ):
         return None
 
+    target_day = day.strftime('%Y-%m-%d')
     if time:
-        due_date_string = (
-            f"{day.strftime('%Y-%m-%d')} {time}"
-        )
+        target_time: str | None = time
     elif due_date and len(due_date) > 10:
-        existing_time = datetime.fromisoformat(
+        target_time = datetime.fromisoformat(
             due_date
         ).strftime('%H:%M')
-        due_date_string = (
-            f"{day.strftime('%Y-%m-%d')} {existing_time}"
-        )
     else:
-        due_date_string = day.strftime('%Y-%m-%d')
+        target_time = None
 
     if task.due and task.due.is_recurring:
-        # Preserve original due date string for recurring tasks
-        original_due = re.sub(
-            r'\s*starting on.*', '', task.due.string,
-        )
-        due_date_string = (
-            f"{original_due} starting on {due_date_string}"
-        )
+        # See #62: Todoist silently ignores the date in
+        # `<pattern> starting on YYYY-MM-DD HH:MM` and snaps to the
+        # recurrence anchor's weekday. Putting the time inside the
+        # pattern (`<pattern> at HH:MM starting on YYYY-MM-DD`)
+        # makes Todoist honor the requested date.
+        pattern = _strip_recurrence_pattern(task.due.string)
+        if target_time:
+            return (
+                f"{pattern} at {target_time} "
+                f"starting on {target_day}"
+            )
+        return f"{pattern} starting on {target_day}"
 
-    return due_date_string
+    if target_time:
+        return f"{target_day} {target_time}"
+    return target_day
 
 
 def validate_recurring_preserved(
@@ -89,9 +113,7 @@ def validate_recurring_preserved(
     """
     if not task.due or not task.due.is_recurring:
         return
-    original_pattern = re.sub(
-        r'\s*starting on.*', '', task.due.string,
-    ).strip()
+    original_pattern = _strip_recurrence_pattern(task.due.string)
     if not original_pattern:
         return
     if not due_string.lower().startswith(
@@ -104,6 +126,41 @@ def validate_recurring_preserved(
             f"pattern '{original_pattern}' "
             f"(original: '{task.due.string}')"
         )
+
+
+class DueDateMismatchError(Exception):
+    """Todoist stored a different date than we asked for.
+
+    Raised when read-after-write shows that the task's stored due
+    date doesn't match the date we requested. Catches Todoist API
+    quirks (see #62) and semantic conflicts like trying to move an
+    `every Monday` task to a Tuesday — Todoist silently snaps to a
+    valid recurrence date and our agent would otherwise report
+    success on a wrong date.
+    """
+
+
+def _verify_due_date_matches(
+    api: TodoistAPI,
+    task_id: str,
+    expected_day: date,
+    due_string: str,
+) -> None:
+    """Re-fetch the task and confirm Todoist stored our date."""
+    fresh = api.get_task(task_id=task_id)
+    actual_date = _parse_task_date(fresh)
+    if actual_date == expected_day:
+        return
+    actual_due = (
+        str(fresh.due.date)  # pyright: ignore[reportUnknownMemberType,reportUnknownArgumentType]
+        if fresh.due else None
+    )
+    raise DueDateMismatchError(
+        f"Todoist stored {actual_due!r} for task "
+        f"{task_id} ('{fresh.content}') after we sent "
+        f"due_string={due_string!r} targeting "
+        f"{expected_day.isoformat()}."
+    )
 
 
 def reschedule_task(
@@ -153,6 +210,10 @@ def reschedule_task(
         raise Exception(
             f"Failed to reschedule task: {task.content}"
         )
+
+    # Read-after-write: catches Todoist quirks that silently shift
+    # the date (#62) and recurrence/weekday semantic conflicts.
+    _verify_due_date_matches(api, task.id, day, due_string)
 
     # Restore reminders after the update
     if reminders:

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import MagicMock, call
+from unittest.mock import MagicMock, call, patch
 from datetime import date, timedelta
 
 from todoist_scheduler.scheduler import Scheduler
@@ -72,6 +72,13 @@ class TestScheduling(unittest.TestCase):
         self.scheduler = Scheduler(
             self.api, self.today, self.tasks_per_day, self.ignore_tag
         )
+        # Skip read-after-write verification in scheduler tests —
+        # they exercise push-down logic, not the wire format.
+        self._verify_patcher = patch(
+            'todoist_scheduler.reschedule._verify_due_date_matches'
+        )
+        self._verify_patcher.start()
+        self.addCleanup(self._verify_patcher.stop)
 
     def test_schedule_no_tasks(self):
         self.scheduler.schedule_and_push_down([])
@@ -153,7 +160,10 @@ class TestScheduling(unittest.TestCase):
         self.api.filter_tasks.return_value = iter([])
         self.scheduler.schedule_and_push_down(tasks_to_add)
 
-        expected_due_string = f"every week at 5pm starting on {self.today.strftime('%Y-%m-%d')} 17:00"
+        expected_due_string = (
+            f"every week at 17:00 starting on "
+            f"{self.today.strftime('%Y-%m-%d')}"
+        )
         self.api.update_task.assert_called_once_with(
             task_id='1',
             due_string=expected_due_string

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -78,18 +78,23 @@ class TestMain(unittest.TestCase):
         mock_config.USER_TZ = "UTC"
         mock_api = MagicMock()
         mock_api_cls.return_value = mock_api
-        task = create_task(
+        task_before = create_task(
             "1", "My Task",
             due_date_str="2026-03-01",
         )
-        mock_api.get_task.return_value = task
+        task_after = create_task(
+            "1", "My Task",
+            due_date_str="2026-03-15",
+        )
+        # Two get_task calls: CLI fetch, then read-after-write
+        # verification inside reschedule_task.
+        mock_api.get_task.side_effect = [
+            task_before, task_after,
+        ]
         mock_api.update_task.return_value = True
 
         main(["1", "2026-03-15"])
 
-        mock_api.get_task.assert_called_once_with(
-            task_id="1",
-        )
         mock_api.update_task.assert_called_once_with(
             task_id="1",
             due_string="2026-03-15",

--- a/tests/test_nightly.py
+++ b/tests/test_nightly.py
@@ -88,6 +88,13 @@ class TestSchedulerDryRun(unittest.TestCase):
         self.api = MagicMock()
         self.api.update_task.return_value = True
         self.today = date(2026, 4, 6)
+        # Skip read-after-write check; these tests exercise the
+        # scheduler push-down, not the wire format.
+        self._verify_patcher = patch(
+            "todoist_scheduler.reschedule._verify_due_date_matches"
+        )
+        self._verify_patcher.start()
+        self.addCleanup(self._verify_patcher.stop)
 
     def test_dry_run_collects_moves(self) -> None:
         scheduler = Scheduler(

--- a/tests/test_reschedule.py
+++ b/tests/test_reschedule.py
@@ -1,3 +1,4 @@
+import re
 import unittest
 from unittest.mock import MagicMock, patch
 from datetime import date
@@ -5,6 +6,9 @@ from datetime import date
 from todoist_api_python.models import Duration
 
 from todoist_scheduler.reschedule import (
+    DueDateMismatchError,
+    _strip_recurrence_pattern,
+    _verify_due_date_matches,
     compute_due_string,
     reschedule_task,
     validate_recurring_preserved,
@@ -70,7 +74,10 @@ class TestComputeDueString(unittest.TestCase):
             due_datetime_str='2024-01-10T17:00:00Z'
         )
         result = compute_due_string(task, date(2024, 1, 15))
-        self.assertEqual(result, 'every week at 5pm starting on 2024-01-15 17:00')
+        self.assertEqual(
+            result,
+            'every week at 17:00 starting on 2024-01-15',
+        )
 
     def test_recurring_strips_existing_starting_on(self):
         task = create_task(
@@ -81,7 +88,10 @@ class TestComputeDueString(unittest.TestCase):
             due_datetime_str='2024-01-10T17:00:00Z'
         )
         result = compute_due_string(task, date(2024, 1, 15))
-        self.assertEqual(result, 'every week at 5pm starting on 2024-01-15 17:00')
+        self.assertEqual(
+            result,
+            'every week at 17:00 starting on 2024-01-15',
+        )
 
     def test_no_due(self):
         task = create_task('1', 'Task')
@@ -142,7 +152,7 @@ class TestComputeDueString(unittest.TestCase):
         )
         self.assertEqual(
             result,
-            'every week starting on 2024-01-15 09:30',
+            'every week at 09:30 starting on 2024-01-15',
         )
 
     def test_time_override_recurring_with_existing_time(self):
@@ -158,8 +168,7 @@ class TestComputeDueString(unittest.TestCase):
         )
         self.assertEqual(
             result,
-            'every week at 5pm starting on '
-            '2024-01-15 09:30',
+            'every week at 09:30 starting on 2024-01-15',
         )
 
     def test_time_override_same_day_still_reschedules(self):
@@ -262,6 +271,21 @@ class TestValidateRecurringPreserved(unittest.TestCase):
             'every week starting on 2024-01-15',
         )
 
+    def test_original_at_time_clause_stripped_for_compare(self):
+        # Ensure the new compute_due_string output is accepted even
+        # though it normalizes the `at <time>` part of the pattern.
+        task = create_task(
+            '1', 'Task',
+            due_date_str='2024-01-10',
+            is_recurring=True,
+            due_string='every week at 5pm',
+            due_datetime_str='2024-01-10T17:00:00Z',
+        )
+        validate_recurring_preserved(
+            task,
+            'every week at 09:30 starting on 2024-01-15',
+        )
+
 
 class TestRescheduleTask(unittest.TestCase):
 
@@ -269,6 +293,11 @@ class TestRescheduleTask(unittest.TestCase):
         self.api = MagicMock()
         self.api._token = "tok"
         self.api.update_task.return_value = True
+        # Default read-after-write: Todoist stored what we asked
+        # for. Individual tests override to simulate a mismatch.
+        self.api.get_task.return_value = create_task(
+            '1', 'Task', due_date_str='2024-01-15',
+        )
 
     def test_calls_api(self):
         task = create_task('1', 'Task', due_date_str='2024-01-10')
@@ -353,10 +382,27 @@ class TestRescheduleTask(unittest.TestCase):
         self.api.update_task.assert_called_once_with(
             task_id='1',
             due_string=(
-                'every week starting on '
-                '2024-01-15 09:30'
+                'every week at 09:30 starting on '
+                '2024-01-15'
             ),
         )
+
+    def test_raises_on_post_write_date_mismatch(self):
+        # Simulates the #62 class of failure: Todoist accepts our
+        # update but stores a different date than we asked for.
+        self.api.get_task.return_value = create_task(
+            '1', 'Task',
+            due_date_str='2024-01-22',
+            due_datetime_str='2024-01-22 17:00:00',
+        )
+        task = create_task(
+            '1', 'Task',
+            due_date_str='2024-01-10',
+            is_recurring=True,
+            due_string='every Monday',
+        )
+        with self.assertRaises(DueDateMismatchError):
+            reschedule_task(self.api, task, date(2024, 1, 15))
 
     @patch(
         "todoist_scheduler.reschedule.fetch_reminders"
@@ -427,6 +473,160 @@ class TestRescheduleTask(unittest.TestCase):
             mock_fetch.return_value,
             5,
         )
+
+
+class TestStripRecurrencePattern(unittest.TestCase):
+
+    def test_strips_starting_on(self):
+        self.assertEqual(
+            _strip_recurrence_pattern(
+                'every week starting on 2024-01-15 17:00',
+            ),
+            'every week',
+        )
+
+    def test_strips_at_24h_time(self):
+        self.assertEqual(
+            _strip_recurrence_pattern('every week at 17:00'),
+            'every week',
+        )
+
+    def test_strips_at_5pm(self):
+        self.assertEqual(
+            _strip_recurrence_pattern('every week at 5pm'),
+            'every week',
+        )
+
+    def test_strips_at_5_30pm(self):
+        self.assertEqual(
+            _strip_recurrence_pattern('every week at 5:30pm'),
+            'every week',
+        )
+
+    def test_strips_at_9am(self):
+        self.assertEqual(
+            _strip_recurrence_pattern('every weekday at 9am'),
+            'every weekday',
+        )
+
+    def test_strips_both_at_and_starting_on(self):
+        self.assertEqual(
+            _strip_recurrence_pattern(
+                'every! week at 5pm starting on 2024-01-01 17:00',
+            ),
+            'every! week',
+        )
+
+    def test_no_change_when_no_clauses(self):
+        self.assertEqual(
+            _strip_recurrence_pattern('every Monday'),
+            'every Monday',
+        )
+
+
+class TestComputeDueStringRegressionFor62(unittest.TestCase):
+    """#62 — Todoist silently snaps to the recurrence anchor's
+    weekday when the due_string is `<pattern> starting on
+    YYYY-MM-DD HH:MM`. We must never emit that format for a
+    recurring task with a target time."""
+
+    BAD_FORMAT = re.compile(
+        r'starting on \d{4}-\d{2}-\d{2} \d{1,2}:\d{2}',
+    )
+
+    PATTERNS = [
+        'every week',
+        'every! week',
+        'daily',
+        'every 2 weeks',
+        'every month',
+        'every Monday',
+        'every weekday',
+        'every week at 5pm',
+        'every! week at 17:00',
+    ]
+
+    def test_no_bad_format_with_explicit_time(self):
+        for pattern in self.PATTERNS:
+            with self.subTest(pattern=pattern):
+                task = create_task(
+                    '1', 'Task',
+                    due_date_str='2024-01-10',
+                    is_recurring=True,
+                    due_string=pattern,
+                )
+                result = compute_due_string(
+                    task, date(2024, 1, 15), time='17:00',
+                )
+                assert result is not None
+                self.assertNotRegex(result, self.BAD_FORMAT)
+                self.assertIn(' at 17:00 ', result)
+                self.assertTrue(
+                    result.endswith('starting on 2024-01-15')
+                )
+
+    def test_no_bad_format_with_inherited_time(self):
+        # Time inherited from existing due_datetime, not passed in.
+        for pattern in self.PATTERNS:
+            with self.subTest(pattern=pattern):
+                task = create_task(
+                    '1', 'Task',
+                    due_date_str='2024-01-10',
+                    is_recurring=True,
+                    due_string=pattern,
+                    due_datetime_str='2024-01-10T17:00:00Z',
+                )
+                result = compute_due_string(
+                    task, date(2024, 1, 15),
+                )
+                assert result is not None
+                self.assertNotRegex(result, self.BAD_FORMAT)
+
+
+class TestVerifyDueDateMatches(unittest.TestCase):
+
+    def test_match_passes(self):
+        api = MagicMock()
+        api.get_task.return_value = create_task(
+            '1', 'Task', due_date_str='2024-01-15',
+        )
+        # Should not raise.
+        _verify_due_date_matches(
+            api, '1', date(2024, 1, 15), 'sent',
+        )
+
+    def test_date_mismatch_raises(self):
+        api = MagicMock()
+        api.get_task.return_value = create_task(
+            '1', 'Task', due_date_str='2024-01-20',
+        )
+        with self.assertRaises(DueDateMismatchError) as ctx:
+            _verify_due_date_matches(
+                api, '1', date(2024, 1, 15), 'sent string',
+            )
+        msg = str(ctx.exception)
+        self.assertIn('2024-01-20', msg)
+        self.assertIn('2024-01-15', msg)
+        self.assertIn('sent string', msg)
+
+    def test_datetime_compared_by_date_only(self):
+        api = MagicMock()
+        api.get_task.return_value = create_task(
+            '1', 'Task',
+            due_date_str='2024-01-15',
+            due_datetime_str='2024-01-15T17:00:00',
+        )
+        _verify_due_date_matches(
+            api, '1', date(2024, 1, 15), 'sent',
+        )
+
+    def test_no_due_after_write_raises(self):
+        api = MagicMock()
+        api.get_task.return_value = create_task('1', 'Task')
+        with self.assertRaises(DueDateMismatchError):
+            _verify_due_date_matches(
+                api, '1', date(2024, 1, 15), 'sent',
+            )
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
closes #62

## Summary

- Recurring reschedules now emit `<pattern> at HH:MM starting on YYYY-MM-DD` instead of the broken `<pattern> starting on YYYY-MM-DD HH:MM` — the latter format causes Todoist to silently ignore the date and snap to the recurrence anchor's existing weekday.
- Added a read-after-write check in `reschedule_task` that re-fetches the task and raises `DueDateMismatchError` if Todoist stored a different date than we asked for. Catches future quirks of the same shape and semantic conflicts (e.g. moving an `every Monday` task to a Tuesday).
- Added regression tests asserting the bad format is never emitted across common recurrence patterns.

## Repro evidence

Verified directly against the Todoist API in a `test` project. Bad format silently dropped to a wrong weekday across every recurrence type tested (`daily`, `every week`, `every! week`, `every 2 weeks`, `every Monday`, `every month`). The new format is honored correctly in every case except `every Monday` → Tuesday, which is a real semantic conflict — and the read-after-write check now surfaces that case as an error instead of a silent success.

## Test plan

- [x] `uv run pytest` — 247 passed
- [x] `uv run pyright` — 0 errors
- [x] Live verify after merge: reschedule a recurring `every! week` task with a time in the test project and confirm the stored date matches the request