### PR TITLE
Show recurrence string in pre-loaded task context (#59)

### DIFF
--- a/src/planning_agent/context.py
+++ b/src/planning_agent/context.py
@@ -56,7 +56,7 @@ def _fmt_task(task: Task) -> str:
         if task.due else "no due date"
     )
     recurring = (
-        " (recurring)"
+        f" ({task.due.string})"
         if task.due and task.due.is_recurring
         else ""
     )

--- a/tests/test_planning_agent.py
+++ b/tests/test_planning_agent.py
@@ -98,14 +98,24 @@ class TestFmtTask:
         result = _fmt_task(task)
         assert "no due date" in result
 
-    def test_recurring_shown(self):
+    def test_recurring_shows_pattern(self):
         task = create_task(
             "789", "Daily standup",
             due_date_str="2026-03-14",
             is_recurring=True,
+            due_string="every weekday",
         )
         result = _fmt_task(task)
-        assert "(recurring)" in result
+        assert "(every weekday)" in result
+        assert "(recurring)" not in result
+
+    def test_non_recurring_has_no_pattern(self):
+        task = create_task(
+            "790", "One-off errand",
+            due_date_str="2026-03-14",
+        )
+        result = _fmt_task(task)
+        assert "(" not in result
 
     def test_priority_mapping(self):
         task = create_task(


### PR DESCRIPTION
closes #59

## Summary

`_fmt_task()` now formats recurring tasks with the actual recurrence
rule (`task.due.string`, e.g. `every week`, `every 3rd Monday`)
instead of a bare `(recurring)` flag.

Before:
```
[12345] Check finances | due: 2026-04-19 (recurring) | p4
```

After:
```
[12345] Check finances | due: 2026-04-19 (every week) | p4
```

## Why

Without the rule string, the agent can't reason about cadence
(weekly vs monthly) or recreate a broken recurrence — a contributing
visibility gap during the #55 data-loss incident.

## Test plan

- [x] `uv run pytest` — 251 passed
- [x] `uv run pyright` — 0 errors
- [x] Updated `test_recurring_shows_pattern` to assert the rule
      surfaces; added `test_non_recurring_has_no_pattern` to verify
      one-off tasks are unchanged.