### PR TITLE
Allow update_task to move tasks between projects (#60)

### DIFF
--- a/src/todoist_mcp/server.py
+++ b/src/todoist_mcp/server.py
@@ -205,17 +205,21 @@ def update_task(
     description: Optional[str] = None,
     priority: Optional[int] = None,
     labels: Optional[list[str]] = None,
+    project_id: Optional[str] = None,
 ) -> str:
-    """Update a task's content, description, priority, or labels.
+    """Update a task's fields or move it to a different project.
 
     NOTE: To change a task's due date use reschedule_tasks instead —
     it safely preserves recurring patterns and reminders.
 
     priority: 1=lowest (p4), 2=p3, 3=p2, 4=highest (p1).
+    project_id: if set, moves the task to that project before
+        applying any other field updates.
     """
     return _tools.update_task(
         _require_api(),
         task_id, content, description, priority, labels,
+        project_id=project_id,
     )
 
 

--- a/src/todoist_mcp/tools.py
+++ b/src/todoist_mcp/tools.py
@@ -224,6 +224,7 @@ def update_task(
     description: Optional[str] = None,
     priority: Optional[int] = None,
     labels: Optional[list[str]] = None,
+    project_id: Optional[str] = None,
 ) -> str:
     try:
         kwargs: dict[str, Any] = {}
@@ -235,9 +236,12 @@ def update_task(
             kwargs["priority"] = priority
         if labels is not None:
             kwargs["labels"] = labels
-        if not kwargs:
+        if project_id is None and not kwargs:
             return "No changes specified."
-        api.update_task(task_id=task_id, **kwargs)
+        if project_id is not None:
+            api.move_task(task_id=task_id, project_id=project_id)
+        if kwargs:
+            api.update_task(task_id=task_id, **kwargs)
         task = api.get_task(task_id=task_id)
         return f"Updated: {fmt_task(task)}"
     except Exception as e:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -319,6 +319,33 @@ class TestUpdateTask:
         mock_api.update_task.side_effect = Exception("fail")
         assert update_task("1", content="x").startswith("Error:")
 
+    def test_project_id_alone_moves_task(self, mock_api):
+        mock_api.get_task.return_value = _task()
+        result = update_task("1", project_id="proj-2")
+        mock_api.move_task.assert_called_once_with(
+            task_id="1", project_id="proj-2"
+        )
+        mock_api.update_task.assert_not_called()
+        assert "Updated" in result
+
+    def test_project_id_with_other_fields(self, mock_api):
+        mock_api.get_task.return_value = _task(content="Renamed")
+        update_task("1", content="Renamed", project_id="proj-2")
+        mock_api.move_task.assert_called_once_with(
+            task_id="1", project_id="proj-2"
+        )
+        mock_api.update_task.assert_called_once_with(
+            task_id="1", content="Renamed"
+        )
+
+    def test_no_kwargs_does_not_call_move(self, mock_api):
+        update_task("1")
+        mock_api.move_task.assert_not_called()
+
+    def test_move_error_returned(self, mock_api):
+        mock_api.move_task.side_effect = Exception("fail")
+        assert update_task("1", project_id="p2").startswith("Error:")
+
 
 # ---------------------------------------------------------------------------
 # complete_task


### PR DESCRIPTION
closes #60

## Summary

`update_task` now accepts an optional `project_id`. When set, the
task is moved to that project; other fields (content, description,
priority, labels) update afterward in the same call.

## Why the implementation differs from the issue

The issue suggested adding `project_id` to `api.update_task` kwargs.
The Todoist SDK actually splits these operations: `api.update_task`
handles fields, `api.move_task` handles project / section / parent
moves. The MCP tool keeps a single `update_task` surface for the
agent and dispatches to both internally:

1. If `project_id` is set, call `api.move_task(task_id, project_id=...)`.
2. If any field kwargs are set, call `api.update_task(task_id, **kwargs)`.
3. Re-fetch and return the task.

Move runs first so a failed move aborts before any field updates land.

## Test plan

- [x] `uv run pytest` — 255 passed
- [x] `uv run pyright` — 0 errors
- [x] New tests: `project_id` alone moves and skips `update_task`;
      `project_id` + `content` calls both; existing
      "no changes specified" guard intact; move errors propagate.