### PR TITLE
Direct agent to use pre-loaded Inbox ID for Inbox queries (#61)

### DIFF
--- a/src/planning_agent/agent.py
+++ b/src/planning_agent/agent.py
@@ -164,7 +164,10 @@ relevant.
   search against task titles. Use this when looking \
   up a task by name.
 - `find_tasks(project_id)` — all tasks in a project. \
-  Use `get_projects()` first to look up the ID.
+  The Inbox project ID is already in the pre-loaded \
+  "Todoist projects" section below — use it directly. \
+  For other projects, call `get_projects()` to look up \
+  the ID.
 - `find_tasks_by_date(start_date, end_date)` — date \
   range.
 - `get_task(task_id)` — details on one task.
@@ -306,6 +309,9 @@ def create_agent(
 
 ### Todoist projects
 {deps.inbox_project}
+When the user asks about Inbox tasks, pass this ID as
+`project_id` to `find_tasks` or `get_overview` — do not
+call `get_projects()` to look it up again.
 
 ### Tasks (overdue + next 14 days)
 {deps.todoist_snapshot}


### PR DESCRIPTION
closes #61

## Summary

The Inbox project ID is already pre-loaded into the system prompt
(\`### Todoist projects\` section, via #48). The agent kept telling
users it couldn't view Inbox tasks because two prompt fragments
told it to call \`get_projects()\` first to discover project IDs —
so it never connected the pre-loaded value to "the user is asking
about Inbox."

## Changes

- \`find_tasks(project_id)\` tool doc now points at the pre-loaded
  section for Inbox and frames \`get_projects()\` as the fallback
  for non-Inbox projects.
- The rendered \`### Todoist projects\` block now appends a
  one-line directive telling the agent to pass the pre-loaded ID
  directly for Inbox queries.

## Why prompt-only

The data layer already does the right thing — \`_fetch_inbox_project()\`
runs at session startup and the value is rendered into the system
prompt. The bug was that the prompt didn't tell the agent to use
that value. No tool changes, no new convenience parameter (which
would have leaked Inbox-specific semantics into the MCP tools).

## Test plan

- [x] \`uv run pytest\` — 255 passed
- [x] \`uv run pyright\` — 0 errors
- [ ] Live verification: ask the agent "what's in my Inbox?" on the
      deployed instance once this is merged + redeployed; confirm
      it lists Inbox tasks without first calling \`get_projects()\`.