### PR TITLE
Verify time component in read-after-write check (#66)

### DIFF
--- a/src/todoist_scheduler/reschedule.py
+++ b/src/todoist_scheduler/reschedule.py
@@ -145,22 +145,42 @@ def _verify_due_date_matches(
     task_id: str,
     expected_day: date,
     due_string: str,
+    expected_time: str | None = None,
 ) -> None:
-    """Re-fetch the task and confirm Todoist stored our date."""
+    """Re-fetch the task and confirm Todoist stored our date.
+
+    When ``expected_time`` is given (HH:MM), also verifies the
+    stored time matches. Catches silent time corruption from
+    recurrence strings that embed a time-of-day in formats our
+    normalization doesn't strip — see #66.
+    """
     fresh = api.get_task(task_id=task_id)
     actual_date = _parse_task_date(fresh)
-    if actual_date == expected_day:
-        return
     actual_due = (
         str(fresh.due.date)  # pyright: ignore[reportUnknownMemberType,reportUnknownArgumentType]
         if fresh.due else None
     )
-    raise DueDateMismatchError(
-        f"Todoist stored {actual_due!r} for task "
-        f"{task_id} ('{fresh.content}') after we sent "
-        f"due_string={due_string!r} targeting "
-        f"{expected_day.isoformat()}."
-    )
+    if actual_date != expected_day:
+        raise DueDateMismatchError(
+            f"Todoist stored {actual_due!r} for task "
+            f"{task_id} ('{fresh.content}') after we sent "
+            f"due_string={due_string!r} targeting "
+            f"{expected_day.isoformat()}."
+        )
+    if expected_time is None:
+        return
+    actual_time: str | None = None
+    if actual_due and len(actual_due) > 10:
+        actual_time = datetime.fromisoformat(
+            actual_due
+        ).strftime("%H:%M")
+    if actual_time != expected_time:
+        raise DueDateMismatchError(
+            f"Todoist stored time {actual_time!r} for task "
+            f"{task_id} ('{fresh.content}') after we sent "
+            f"due_string={due_string!r} targeting time "
+            f"{expected_time!r}."
+        )
 
 
 def reschedule_task(
@@ -213,7 +233,10 @@ def reschedule_task(
 
     # Read-after-write: catches Todoist quirks that silently shift
     # the date (#62) and recurrence/weekday semantic conflicts.
-    _verify_due_date_matches(api, task.id, day, due_string)
+    # Also verifies the time when one was requested (#66).
+    _verify_due_date_matches(
+        api, task.id, day, due_string, expected_time=time,
+    )
 
     # Restore reminders after the update
     if reminders:

--- a/tests/test_reschedule.py
+++ b/tests/test_reschedule.py
@@ -356,6 +356,11 @@ class TestRescheduleTask(unittest.TestCase):
         )
 
     def test_time_override_passed_to_api(self):
+        self.api.get_task.return_value = create_task(
+            '1', 'Task',
+            due_date_str='2024-01-15',
+            due_datetime_str='2024-01-15T09:30:00',
+        )
         task = create_task(
             '1', 'Task', due_date_str='2024-01-10',
         )
@@ -369,6 +374,11 @@ class TestRescheduleTask(unittest.TestCase):
         )
 
     def test_recurring_with_time_preserves_pattern(self):
+        self.api.get_task.return_value = create_task(
+            '1', 'Task',
+            due_date_str='2024-01-15',
+            due_datetime_str='2024-01-15T09:30:00',
+        )
         task = create_task(
             '1', 'Task',
             due_date_str='2024-01-10',
@@ -626,6 +636,49 @@ class TestVerifyDueDateMatches(unittest.TestCase):
         with self.assertRaises(DueDateMismatchError):
             _verify_due_date_matches(
                 api, '1', date(2024, 1, 15), 'sent',
+            )
+
+    def test_time_match_passes(self):
+        api = MagicMock()
+        api.get_task.return_value = create_task(
+            '1', 'Task',
+            due_date_str='2024-01-15',
+            due_datetime_str='2024-01-15T17:00:00',
+        )
+        _verify_due_date_matches(
+            api, '1', date(2024, 1, 15), 'sent',
+            expected_time='17:00',
+        )
+
+    def test_time_mismatch_raises(self):
+        api = MagicMock()
+        api.get_task.return_value = create_task(
+            '1', 'Task',
+            due_date_str='2024-01-15',
+            due_datetime_str='2024-01-15T20:00:00',
+        )
+        with self.assertRaises(DueDateMismatchError) as ctx:
+            _verify_due_date_matches(
+                api, '1', date(2024, 1, 15), 'sent string',
+                expected_time='17:00',
+            )
+        msg = str(ctx.exception)
+        self.assertIn('20:00', msg)
+        self.assertIn('17:00', msg)
+        self.assertIn('sent string', msg)
+
+    def test_time_requested_but_stored_date_only_raises(self):
+        # Silent time-corruption case: we asked for 17:00 but
+        # Todoist stored a date-only result. The date check passes;
+        # the time check should fail.
+        api = MagicMock()
+        api.get_task.return_value = create_task(
+            '1', 'Task', due_date_str='2024-01-15',
+        )
+        with self.assertRaises(DueDateMismatchError):
+            _verify_due_date_matches(
+                api, '1', date(2024, 1, 15), 'sent',
+                expected_time='17:00',
             )
 
 


### PR DESCRIPTION
closes #66

## Summary

Extend the read-after-write guard from #62 to also verify the time
component. Closes a class of silent time corruption: recurrence
strings like \`every 3rd friday 8pm\` embed time-of-day in formats
\`_strip_recurrence_pattern\` doesn't catch, and the resulting
double-time output can let Todoist store the wrong time while
keeping the right date. The date check passed; the time slipped
through.

## Changes

- \`_verify_due_date_matches\` takes an optional \`expected_time\`
  (HH:MM). When set, it parses the stored \`due.date\` (when it's a
  datetime ISO string) and raises \`DueDateMismatchError\` on mismatch.
  Includes the case where a time was requested but Todoist stored a
  date-only result.
- Date-only reschedules pass \`expected_time=None\` and behave as
  before — no time check.
- \`reschedule_task\` passes through its existing \`time\` argument.

## Why not strip every Todoist time-spec format

Per the issue: teaching \`_strip_recurrence_pattern\` about every
shape Todoist accepts is a deeper rabbit hole. This guard catches
the silent-corruption symptom regardless of root cause.

## Test plan

- [x] \`uv run pytest\` — 258 passed
- [x] \`uv run pyright\` — 0 errors
- [x] New tests: time match, time mismatch (with both stored and
      requested times in the error), date-only request with stored
      datetime continues to pass, time requested but stored
      date-only raises (the silent-corruption case).
- [x] Two pre-existing tests that asserted \`reschedule_task\` with
      \`time='09:30'\` now seed \`get_task\` with a stored datetime
      so the new time check passes.