### PR TITLE
feat: lazy preload mode for build_context() (#73)

### DIFF
--- a/MILESTONES.md
+++ b/MILESTONES.md
@@ -186,7 +186,7 @@ job stays full-context. Also clear the orphaned bug/cleanup backlog.
   verified via `flyctl machine status -d` showing no token in env block.
 
 **Tasks:**
-- [ ] Add `lazy: bool` param + count fields to `build_context()` /
+- [x] Add `lazy: bool` param + count fields to `build_context()` /
   `PlanningContext`; refactor `_fetch_calendar_snapshot()` to take
   `days: int`. (#73)
 - [ ] Branch `build_system_prompt` on `deps.is_lazy` to render full

--- a/MILESTONES.md
+++ b/MILESTONES.md
@@ -128,7 +128,7 @@ from today and earlier, and spreads them forward using the existing
   (replaces local cron docs). (#54)
 
 
-## Milestone 5: Fuzzy Recurring Tasks — `in-progress`
+## Milestone 5: Fuzzy Recurring Tasks — `planned`
 **Goal:** Add the fuzzy-recurring-task subsystem: a `fuzzy_recurring.json`
 store, MCP tools to manage it, and agent integration so maintenance tasks
 (e.g. "check spare tire ~every 6 months") surface during weekly planning.
@@ -159,7 +159,53 @@ Post-v1 but self-contained.
   seasonal suppression, and `update_last_done` persistence. (#25)
 
 
-## Milestone 6: Scheduling Pattern Learning — `planned`
+## Milestone 6: Interactive Cost Reduction & Cleanup — `in-progress`
+**Goal:** Slim down per-turn cost of interactive (CLI/web) sessions by
+switching to lazy-context mode where tasks, calendar, memories, and
+recent conversations are fetched on demand instead of pre-loaded. Nightly
+job stays full-context. Also clear the orphaned bug/cleanup backlog.
+
+**Acceptance Criteria:**
+- Interactive entry points (`main_cli`, `main_web`) start without
+  fetching the 14-day Todoist/GCal snapshots; pre-load only
+  `values_doc`, `inbox_project`, `current_datetime`, `day_type`, and
+  cheap counts (overdue, upcoming, memories, conversations).
+- Three new agent tools work: `get_calendar(days)`, `get_memories()`,
+  `get_recent_conversations(count)`.
+- `STATIC_PROMPT` has a "Lazy Context" section naming the fetch tools
+  and instructing the agent when to call them.
+- Nightly job (`main_nightly`) continues full-context preload.
+- Logfire shows a measurable drop in input tokens for short
+  interactive sessions vs. baseline.
+- `update_task` advertised in `STATIC_PROMPT`; CI test asserts every
+  `@mcp.tool()` is either advertised or on an explicit
+  `INTENTIONALLY_UNADVERTISED` allowlist.
+- Agent text before/after a tool call renders on separate lines in
+  the web UI.
+- Fly cron Machine redeployed with bearer token as a Fly secret,
+  verified via `flyctl machine status -d` showing no token in env block.
+
+**Tasks:**
+- [ ] Add `lazy: bool` param + count fields to `build_context()` /
+  `PlanningContext`; refactor `_fetch_calendar_snapshot()` to take
+  `days: int`. (#73)
+- [ ] Branch `build_system_prompt` on `deps.is_lazy` to render full
+  preload vs shape-summary; add "Lazy Context" section to
+  `STATIC_PROMPT`. (#74)
+- [ ] Add `get_calendar`, `get_memories`, `get_recent_conversations`
+  agent tools. (#75)
+- [ ] Wire `main_cli.py` and `main_web.py` to pass `lazy=True`; leave
+  `main_nightly.py` as `lazy=False`. (#76)
+- [ ] Tests: lazy-mode context (no upstream fetch, counts only),
+  shape-summary rendering, three new tools. (#77)
+- [ ] Advertise `update_task` in `STATIC_PROMPT`; add registry-coverage
+  test for `@mcp.tool()` drift. (#71)
+- [ ] Fix agent text rendering before/after tool calls in web UI. (#72)
+- [ ] Redeploy Fly cron Machine with bearer token as a Fly secret per
+  DECISIONS.md. (#57)
+
+
+## Milestone 7: Scheduling Pattern Learning — `planned`
 **Goal:** Extend the post-conversation extraction pipeline to capture
 scheduling patterns (completion rates, duration accuracy, deferral
 tendencies) in `scheduling_patterns.json`. Load these patterns into
@@ -201,7 +247,7 @@ observed behavior.
 - [ ] Add tests for pattern loading, updating, and consolidation. (#34)
 
 
-## Milestone 7: Evaluation Suite — `planned`
+## Milestone 8: Evaluation Suite — `planned`
 **Goal:** Build automated evaluation tooling so system prompt and context
 changes can be measured rather than eyeballed. Uses real session data
 already captured by Logfire.

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,10 +1,24 @@
 # Status
 
-**Last updated:** 2026-04-28 (session 8)
-**Active milestone:** Milestone 5 — Fuzzy Recurring Tasks
+**Last updated:** 2026-05-02 (session 9)
+**Active milestone:** Milestone 6 — Interactive Cost Reduction & Cleanup
 
 ## Recently Completed
 
+- **Milestone 6 opened** (2026-05-02). Goal: switch interactive
+  (CLI/web) sessions to lazy-context mode where tasks, calendar,
+  memories, and recent conversations are fetched on demand
+  instead of pre-loaded. Nightly job stays full-context. Also
+  rolls in orphan bug/cleanup work (#57, #71, #72). Confirmed
+  Anthropic prompt caching is on (`agent.py:285-286`), so
+  multi-turn already amortizes; lazy mode targets the short
+  single-turn sessions that don't need the full preload.
+  Renumbered old M6/M7 to M7/M8.
+- **#73 PR open** (#78). `build_context(lazy=True)` skips GCal
+  fetch and replaces the Todoist snapshot with a placeholder;
+  counts (`n_overdue`, `n_upcoming`, `n_memories`,
+  `n_conversations`) flow through for the shape-summary prompt
+  in #74. Awaiting merge.
 - **Live verification on `e28f1b2`** (2026-04-28).
   - **#61 Inbox visibility** — confirmed working. Agent answers
     Inbox queries directly without calling `get_projects()`.
@@ -62,17 +76,18 @@
 
 ## In Progress
 
-Nothing actively in progress.
+- **#73** — lazy `build_context()`. PR #78 open, awaiting merge.
 
 ## Next Up
 
-1. **#71** — advertise `update_task` in `STATIC_PROMPT` and add
-   the `@mcp.tool()` registry-coverage test. Issue body has the
-   expanded scope.
-2. **#72** — UI tool-call interleaving fix. Lower priority.
-3. **#57 production steps** — redeploy cron Machine using updated
-   DEPLOY.md instructions. Token already rotated.
-4. **Resume Milestone 5** — Fuzzy Recurring Tasks (#20–#25).
+1. **#74** — branch `build_system_prompt` on `is_lazy`; add
+   "Lazy Context" section to `STATIC_PROMPT`. Depends on #73.
+2. **#75** — add `get_calendar`, `get_memories`,
+   `get_recent_conversations` tools.
+3. **#76** — wire `main_cli` and `main_web` to `lazy=True`.
+4. **#77** — broader tests for lazy mode + new tools.
+5. **#71 / #72 / #57** — orphan cleanup work folded into M6.
+6. **Resume Milestone 5** — Fuzzy Recurring Tasks once M6 lands.
 
 ## Blockers / Open Questions
 

--- a/src/planning_agent/context.py
+++ b/src/planning_agent/context.py
@@ -29,6 +29,7 @@ CALENDAR_NEEDS_RECONNECT = (
 class PlanningContext:
     """Pre-loaded context injected into every conversation."""
 
+    is_lazy: bool
     values_doc: str
     memories: list[dict[str, Any]]
     recent_conversations: list[dict[str, Any]]
@@ -37,6 +38,10 @@ class PlanningContext:
     current_datetime: str
     day_type: str
     inbox_project: str
+    n_overdue: int
+    n_upcoming: int
+    n_memories: int
+    n_conversations: int
 
 
 def _compute_day_type() -> str:
@@ -74,8 +79,14 @@ def _fmt_task(task: Task) -> str:
     )
 
 
-def _fetch_todoist_snapshot(api: TodoistAPI) -> str:
-    """Fetch overdue + next 14 days of tasks."""
+def _fetch_todoist_snapshot(
+    api: TodoistAPI,
+) -> tuple[str, int, int]:
+    """Fetch overdue + next 14 days of tasks.
+
+    Returns ``(snapshot, n_overdue, n_upcoming)``. Lazy mode uses
+    only the counts; full mode renders the snapshot string.
+    """
     lines: list[str] = []
     n_overdue = 0
     n_upcoming = 0
@@ -125,11 +136,11 @@ def _fetch_todoist_snapshot(api: TodoistAPI) -> str:
     except Exception as exc:
         lines.append(f"Error loading Todoist tasks: {exc}")
 
-    return "\n".join(lines)
+    return "\n".join(lines), n_overdue, n_upcoming
 
 
-def _fetch_calendar_snapshot() -> str:
-    """Fetch next 14 days of Google Calendar events.
+def _fetch_calendar_snapshot(days: int = 14) -> str:
+    """Fetch next ``days`` days of Google Calendar events.
 
     Returns a formatted string of events, or a short
     fallback message if credentials are absent or the
@@ -153,7 +164,7 @@ def _fetch_calendar_snapshot() -> str:
         )
 
         today = datetime.now(ZoneInfo(USER_TZ)).date()
-        end_date = today + timedelta(days=13)
+        end_date = today + timedelta(days=days - 1)
         time_min = (
             datetime.combine(today, datetime.min.time())
             .isoformat() + "Z"
@@ -188,7 +199,7 @@ def _fetch_calendar_snapshot() -> str:
         )
 
         if not events:
-            return "No calendar events in next 14 days."
+            return f"No calendar events in next {days} days."
 
         lines: list[str] = []
         for ev in events:
@@ -210,7 +221,7 @@ def _fetch_calendar_snapshot() -> str:
                 start = dt.strftime("%a %b %d %I:%M %p")
             lines.append(f"  {start}: {summary}")
 
-        return "Next 14 days:\n" + "\n".join(lines)
+        return f"Next {days} days:\n" + "\n".join(lines)
 
     except RefreshError:
         return CALENDAR_NEEDS_RECONNECT
@@ -230,27 +241,52 @@ def _fetch_inbox_project(api: TodoistAPI) -> str:
     return "(Inbox project not found)"
 
 
-def build_context() -> PlanningContext:
-    """Assemble full planning context for a conversation."""
+def build_context(lazy: bool = False) -> PlanningContext:
+    """Assemble planning context for a conversation.
+
+    ``lazy=True`` skips the GCal fetch and the rendered task
+    snapshot but still reads task counts from Todoist so the
+    shape summary in the prompt has numbers. Memories and
+    recent conversations are local file reads and are always
+    loaded; the prompt template decides whether to render them.
+    """
     values_doc = read_values()
     memories = get_active()
     conversations = get_recent(count=3)
 
+    n_overdue = 0
+    n_upcoming = 0
+
     if TODOIST_API_KEY:
         api = TodoistAPI(TODOIST_API_KEY)
-        todoist_snapshot = _fetch_todoist_snapshot(api)
+        snapshot, n_overdue, n_upcoming = (
+            _fetch_todoist_snapshot(api)
+        )
+        if lazy:
+            todoist_snapshot = (
+                "(not loaded — call find_tasks /"
+                " find_tasks_by_date)"
+            )
+        else:
+            todoist_snapshot = snapshot
         inbox_project = _fetch_inbox_project(api)
     else:
         todoist_snapshot = "(Todoist not connected)"
         inbox_project = "(Todoist not connected)"
 
-    calendar_snapshot = _fetch_calendar_snapshot()
+    if lazy:
+        calendar_snapshot = (
+            "(not loaded — call get_calendar)"
+        )
+    else:
+        calendar_snapshot = _fetch_calendar_snapshot()
 
     now = datetime.now(ZoneInfo(USER_TZ))
     current_datetime = now.strftime("%A, %B %d, %Y %I:%M %p")
     day_type = _compute_day_type()
 
     return PlanningContext(
+        is_lazy=lazy,
         values_doc=values_doc,
         memories=memories,
         recent_conversations=conversations,
@@ -259,4 +295,8 @@ def build_context() -> PlanningContext:
         current_datetime=current_datetime,
         day_type=day_type,
         inbox_project=inbox_project,
+        n_overdue=n_overdue,
+        n_upcoming=n_upcoming,
+        n_memories=len(memories),
+        n_conversations=len(conversations),
     )

--- a/src/planning_agent/context.py
+++ b/src/planning_agent/context.py
@@ -24,6 +24,18 @@ CALENDAR_NEEDS_RECONNECT = (
     "(Google Calendar needs reconnect)"
 )
 
+# Placeholders rendered into PlanningContext fields in lazy mode
+# so the system prompt template (#74) and any incidental renderer
+# can show them verbatim. Kept as constants so #74's prompt
+# template can import the same strings — renaming a fetch tool
+# only updates one place.
+LAZY_TODOIST_PLACEHOLDER = (
+    "(not loaded — call find_tasks / find_tasks_by_date)"
+)
+LAZY_CALENDAR_PLACEHOLDER = (
+    "(not loaded — call get_calendar)"
+)
+
 
 @dataclass
 class PlanningContext:
@@ -259,14 +271,14 @@ def build_context(lazy: bool = False) -> PlanningContext:
 
     if TODOIST_API_KEY:
         api = TodoistAPI(TODOIST_API_KEY)
+        # Lazy mode still fetches from Todoist: the API is free
+        # and we want exact counts in the shape summary (#74).
+        # The cost we save is prompt tokens, not API calls.
         snapshot, n_overdue, n_upcoming = (
             _fetch_todoist_snapshot(api)
         )
         if lazy:
-            todoist_snapshot = (
-                "(not loaded — call find_tasks /"
-                " find_tasks_by_date)"
-            )
+            todoist_snapshot = LAZY_TODOIST_PLACEHOLDER
         else:
             todoist_snapshot = snapshot
         inbox_project = _fetch_inbox_project(api)
@@ -275,9 +287,7 @@ def build_context(lazy: bool = False) -> PlanningContext:
         inbox_project = "(Todoist not connected)"
 
     if lazy:
-        calendar_snapshot = (
-            "(not loaded — call get_calendar)"
-        )
+        calendar_snapshot = LAZY_CALENDAR_PLACEHOLDER
     else:
         calendar_snapshot = _fetch_calendar_snapshot()
 

--- a/tests/test_planning_agent.py
+++ b/tests/test_planning_agent.py
@@ -142,12 +142,16 @@ class TestFetchTodoistSnapshot:
             [[upcoming_task]],      # date range query
         ]
 
-        result = _fetch_todoist_snapshot(mock_api)
+        result, n_overdue, n_upcoming = (
+            _fetch_todoist_snapshot(mock_api)
+        )
 
         assert "Overdue (1):" in result
         assert "Overdue errand" in result
         assert "Next 14 days (1):" in result
         assert "Upcoming errand" in result
+        assert n_overdue == 1
+        assert n_upcoming == 1
 
     def test_summary_line_with_counts(self):
         mock_api = MagicMock()
@@ -165,9 +169,13 @@ class TestFetchTodoistSnapshot:
             [[t2, t3]],      # upcoming
         ]
 
-        result = _fetch_todoist_snapshot(mock_api)
+        result, n_overdue, n_upcoming = (
+            _fetch_todoist_snapshot(mock_api)
+        )
 
         assert "Total: 1 overdue, 2 upcoming" in result
+        assert n_overdue == 1
+        assert n_upcoming == 2
 
     def test_no_tasks(self):
         mock_api = MagicMock()
@@ -176,9 +184,13 @@ class TestFetchTodoistSnapshot:
             [[]],   # upcoming — empty page
         ]
 
-        result = _fetch_todoist_snapshot(mock_api)
+        result, n_overdue, n_upcoming = (
+            _fetch_todoist_snapshot(mock_api)
+        )
 
         assert "Total: 0 overdue, 0 upcoming" in result
+        assert n_overdue == 0
+        assert n_upcoming == 0
 
     def test_api_error(self):
         mock_api = MagicMock()
@@ -186,10 +198,14 @@ class TestFetchTodoistSnapshot:
             "API down"
         )
 
-        result = _fetch_todoist_snapshot(mock_api)
+        result, n_overdue, n_upcoming = (
+            _fetch_todoist_snapshot(mock_api)
+        )
 
         assert "Error loading Todoist tasks" in result
         assert "API down" in result
+        assert n_overdue == 0
+        assert n_upcoming == 0
 
 
 class TestFetchCalendarSnapshot:
@@ -413,6 +429,74 @@ class TestBuildContext:
         ctx = build_context()
         assert len(ctx.memories) == 1
         assert ctx.memories[0]["id"] == "m_001"
+
+    @patch("planning_agent.context._fetch_calendar_snapshot")
+    @patch("planning_agent.context._fetch_inbox_project")
+    @patch("planning_agent.context._fetch_todoist_snapshot")
+    @patch(
+        "planning_agent.context.TodoistAPI",
+        autospec=True,
+    )
+    @patch(
+        "planning_agent.context.TODOIST_API_KEY",
+        "fake-key",
+    )
+    @patch("planning_agent.context.get_recent")
+    @patch("planning_agent.context.get_active")
+    @patch("planning_agent.context.read_values")
+    def test_lazy_mode_skips_calendar_and_renders_placeholder(
+        self,
+        mock_values, mock_active, mock_recent,
+        _mock_api_cls,
+        mock_todoist_snap, mock_inbox, mock_gcal,
+    ):
+        mock_values.return_value = "vals"
+        mock_active.return_value = [{"id": "m_001"}]
+        mock_recent.return_value = [
+            {"date": "2026-05-01"},
+            {"date": "2026-04-30"},
+        ]
+        mock_todoist_snap.return_value = (
+            "rendered snapshot", 3, 7,
+        )
+        mock_inbox.return_value = "Inbox: ..."
+
+        ctx = build_context(lazy=True)
+
+        # No GCal fetch attempted
+        mock_gcal.assert_not_called()
+        # Lazy flag and counts populated
+        assert ctx.is_lazy is True
+        assert ctx.n_overdue == 3
+        assert ctx.n_upcoming == 7
+        assert ctx.n_memories == 1
+        assert ctx.n_conversations == 2
+        # Snapshot strings are placeholders, not full content
+        assert "not loaded" in ctx.todoist_snapshot
+        assert "not loaded" in ctx.calendar_snapshot
+        assert "rendered snapshot" not in ctx.todoist_snapshot
+
+    @patch("planning_agent.context._save_credentials")
+    @patch("googleapiclient.discovery.build")
+    @patch(
+        "google.oauth2.credentials.Credentials"
+        ".from_authorized_user_file"
+    )
+    @patch("planning_agent.context.GOOGLE_CALENDAR_CREDENTIALS")
+    def test_calendar_snapshot_honors_days_arg(
+        self, mock_path, _mock_creds, mock_build, _mock_save,
+    ):
+        mock_path.exists.return_value = True
+        mock_service = MagicMock()
+        mock_build.return_value = mock_service
+        (
+            mock_service.events.return_value
+            .list.return_value
+            .execute.return_value
+        ) = {"items": []}
+
+        result = _fetch_calendar_snapshot(days=7)
+        assert result == "No calendar events in next 7 days."
 
 
 # -------------------------------------------------------------------

--- a/tests/test_planning_agent.py
+++ b/tests/test_planning_agent.py
@@ -12,6 +12,8 @@ from planning_agent.config import (
 )
 from planning_agent.context import (
     CALENDAR_NEEDS_RECONNECT,
+    LAZY_CALENDAR_PLACEHOLDER,
+    LAZY_TODOIST_PLACEHOLDER,
     PlanningContext,
     _compute_day_type,
     _fetch_calendar_snapshot,
@@ -472,9 +474,39 @@ class TestBuildContext:
         assert ctx.n_memories == 1
         assert ctx.n_conversations == 2
         # Snapshot strings are placeholders, not full content
-        assert "not loaded" in ctx.todoist_snapshot
-        assert "not loaded" in ctx.calendar_snapshot
+        assert ctx.todoist_snapshot == LAZY_TODOIST_PLACEHOLDER
+        assert ctx.calendar_snapshot == LAZY_CALENDAR_PLACEHOLDER
         assert "rendered snapshot" not in ctx.todoist_snapshot
+
+    @patch(
+        "planning_agent.context"
+        ".GOOGLE_CALENDAR_CREDENTIALS"
+    )
+    @patch("planning_agent.context.TODOIST_API_KEY", "")
+    @patch("planning_agent.context.get_recent")
+    @patch("planning_agent.context.get_active")
+    @patch("planning_agent.context.read_values")
+    def test_lazy_mode_without_todoist_key(
+        self, mock_values, mock_active, mock_recent,
+        mock_gcal_path,
+    ):
+        # Lazy + no Todoist key: the "not connected" branch
+        # runs, the lazy branch still rewrites calendar to its
+        # placeholder, and counts stay zero.
+        mock_gcal_path.exists.return_value = False
+        mock_values.return_value = ""
+        mock_active.return_value = []
+        mock_recent.return_value = []
+
+        ctx = build_context(lazy=True)
+
+        assert ctx.is_lazy is True
+        assert ctx.n_overdue == 0
+        assert ctx.n_upcoming == 0
+        assert ctx.n_memories == 0
+        assert ctx.n_conversations == 0
+        assert "(Todoist not connected)" in ctx.todoist_snapshot
+        assert ctx.calendar_snapshot == LAZY_CALENDAR_PLACEHOLDER
 
     @patch("planning_agent.context._save_credentials")
     @patch("googleapiclient.discovery.build")


### PR DESCRIPTION
closes #73

First slice of Milestone 6 (Interactive Cost Reduction). Adds a
`lazy: bool` mode to `build_context()` that interactive entry
points will opt into in #76. Nightly stays full-context.

## Changes
- `PlanningContext` gains `is_lazy` plus `n_overdue`, `n_upcoming`,
  `n_memories`, `n_conversations`.
- `build_context(lazy=True)` skips the GCal fetch entirely and
  replaces the rendered Todoist snapshot with a placeholder. Counts
  still flow through so the lazy system prompt (#74) can render a
  shape summary.
- `_fetch_calendar_snapshot(days: int = 14)` — parameterized so
  the upcoming `get_calendar` tool (#75) can pass a different
  window.
- `_fetch_todoist_snapshot()` now returns
  `(snapshot, n_overdue, n_upcoming)`; existing callers updated.
- Tests: lazy-mode build_context (asserts no GCal call, counts
  populated, placeholders rendered), and `_fetch_calendar_snapshot`
  honoring `days`.
- Docs: opens M6 in MILESTONES.md and renumbers the old M6/M7 to
  M7/M8 to match the GitHub milestones.

## Test plan
- [x] `uv run pytest` — 260 pass
- [x] `uv run pyright` — 0 errors

Note: the system prompt template still renders the same way; lazy
mode isn't visible end-to-end until #74 (prompt branching) and
#76 (entry-point wiring) land.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated milestone sequencing and project status tracking to reflect current development phase, including newly added and reclassified milestones.

* **Chores**
  * Introduced a "lazy" context mode to reduce external data fetching and speed up lightweight operations; calendar and detailed task snapshots are replaced by lightweight placeholders in this mode.

* **Tests**
  * Expanded test coverage to validate lazy-mode behavior, counts/summaries, and calendar time-window handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->