### PR TITLE
feat: branch system prompt on lazy mode (#74)

### DIFF
--- a/src/planning_agent/agent.py
+++ b/src/planning_agent/agent.py
@@ -45,7 +45,9 @@ async def _default_confirm(
         return False
     return answer in ("y", "yes")
 
+from planning_context.conversations import Conversation
 from planning_context.memories import (
+    Memory,
     add_memory as _add_memory,
     resolve_memory as _resolve_memory,
 )
@@ -198,6 +200,28 @@ longer active.
 - `update_values_doc(content)` — rewrite the values doc \
 if priorities have clearly shifted.
 
+## Lazy Context Mode
+
+When the pre-loaded context shows "Available context \
+(call tools to load)" instead of full task lists, \
+calendar events, and memories, you are in lazy mode — \
+only counts have been pre-loaded. Fetch what the \
+question needs before answering:
+
+- Tasks: `find_tasks` (Todoist filter syntax) or \
+`find_tasks_by_date` (date range).
+- Calendar: `get_calendar(days)` — pass the number of \
+days you need.
+- Memories: `get_memories` — full active memory list.
+- Recent conversations: `get_recent_conversations(count)`.
+
+Don't fetch what the question doesn't need. A quick \
+"what's on today?" needs today's tasks and today's \
+calendar — not 14 days of tasks or every memory. A \
+"plan my week" request needs all four. In full mode \
+(no "Available context" header), the data is already \
+in this prompt — don't re-fetch.
+
 ## Conversation Style
 
 - **Short responses.** A sentence or two unless asked.
@@ -223,38 +247,100 @@ time to do what matters.\
 
 
 def _format_memories(
-    memories: list[dict[str, Any]],
+    memories: list[Memory],
 ) -> str:
     if not memories:
         return "(no active memories)"
     lines: list[str] = []
     for m in memories:
         line = (
-            f"[{m['id']}] ({m.get('category', '?')}) "
+            f"[{m['id']}] ({m['category']}) "
             f"{m['content']}"
         )
-        if m.get("expiry_date"):
-            line += f" (expires {m['expiry_date']})"
+        expiry = m.get("expiry_date")
+        if expiry:
+            line += f" (expires {expiry})"
         lines.append(line)
     return "\n".join(lines)
 
 
 def _format_conversations(
-    conversations: list[dict[str, Any]],
+    conversations: list[Conversation],
 ) -> str:
     if not conversations:
         return "(no recent conversations)"
     lines: list[str] = []
     for conv in conversations:
-        d: str = conv.get("date", "?")
-        entries: list[dict[str, Any]] = conv.get(
-            "entries", []
-        )
-        for entry in entries:
+        for entry in conv["entries"]:
             lines.append(
-                f"[{d}] {entry.get('summary', '(no summary)')}"
+                f"[{conv['date']}] {entry['summary']}"
             )
     return "\n".join(lines)
+
+
+def _render_system_prompt(deps: PlanningContext) -> str:
+    """Render the full system prompt for a context.
+
+    Branches on ``deps.is_lazy``:
+    - **Full**: pre-loads task snapshot, calendar, memories,
+      and recent conversations into the prompt.
+    - **Lazy**: replaces those bodies with a shape-summary
+      block telling the agent which tools to call.
+
+    Always-shown sections (values, inbox project ID, current
+    datetime/day type) appear in both modes — they're cheap
+    and the agent needs them up front.
+    """
+    header = f"""{STATIC_PROMPT}
+
+---
+
+## Pre-loaded Context
+
+### Values and priorities
+{deps.values_doc or "(no values document yet)"}"""
+
+    if deps.is_lazy:
+        middle = f"""
+
+### Todoist projects
+{deps.inbox_project}
+When the user asks about Inbox tasks, pass this ID as
+`project_id` to `find_tasks` or `get_overview` — do not
+call `get_projects()` to look it up again.
+
+### Available context (call tools to load)
+- Tasks: {deps.n_overdue} overdue, {deps.n_upcoming} in next 14 days — call find_tasks / find_tasks_by_date
+- Calendar: not loaded — call get_calendar(days)
+- Memories: {deps.n_memories} active — call get_memories
+- Recent conversations: {deps.n_conversations} available — call get_recent_conversations"""
+    else:
+        middle = f"""
+
+### Active memories
+{_format_memories(deps.memories)}
+
+### Recent conversations
+{_format_conversations(deps.recent_conversations)}
+
+### Todoist projects
+{deps.inbox_project}
+When the user asks about Inbox tasks, pass this ID as
+`project_id` to `find_tasks` or `get_overview` — do not
+call `get_projects()` to look it up again.
+
+### Tasks (overdue + next 14 days)
+{deps.todoist_snapshot}
+
+### Calendar (next 14 days)
+{deps.calendar_snapshot}"""
+
+    footer = f"""
+
+### Right now
+{deps.current_datetime} — {deps.day_type} day"""
+
+    return header + middle + footer
 
 
 # -- Agent creation --
@@ -291,36 +377,7 @@ def create_agent(
     async def build_system_prompt(  # pyright: ignore[reportUnusedFunction]
         ctx: RunContext[PlanningContext],
     ) -> str:
-        deps = ctx.deps
-        prompt = f"""{STATIC_PROMPT}
-
----
-
-## Pre-loaded Context
-
-### Values and priorities
-{deps.values_doc or "(no values document yet)"}
-
-### Active memories
-{_format_memories(deps.memories)}
-
-### Recent conversations
-{_format_conversations(deps.recent_conversations)}
-
-### Todoist projects
-{deps.inbox_project}
-When the user asks about Inbox tasks, pass this ID as
-`project_id` to `find_tasks` or `get_overview` — do not
-call `get_projects()` to look it up again.
-
-### Tasks (overdue + next 14 days)
-{deps.todoist_snapshot}
-
-### Calendar (next 14 days)
-{deps.calendar_snapshot}
-
-### Right now
-{deps.current_datetime} — {deps.day_type} day"""
+        prompt = _render_system_prompt(ctx.deps)
         if debug_fn:
             await debug_fn(
                 "system_prompt", {"content": prompt}

--- a/src/planning_agent/context.py
+++ b/src/planning_agent/context.py
@@ -7,8 +7,8 @@ from datetime import datetime, timedelta
 from typing import Any, cast
 from zoneinfo import ZoneInfo
 
-from planning_context.conversations import get_recent
-from planning_context.memories import get_active
+from planning_context.conversations import Conversation, get_recent
+from planning_context.memories import Memory, get_active
 from planning_context.values import read_values
 from todoist_api_python.api import TodoistAPI
 from todoist_api_python.models import Task
@@ -43,8 +43,8 @@ class PlanningContext:
 
     is_lazy: bool
     values_doc: str
-    memories: list[dict[str, Any]]
-    recent_conversations: list[dict[str, Any]]
+    memories: list[Memory]
+    recent_conversations: list[Conversation]
     todoist_snapshot: str
     calendar_snapshot: str
     current_datetime: str

--- a/src/planning_context/conversations.py
+++ b/src/planning_context/conversations.py
@@ -3,11 +3,31 @@
 import logging
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import NotRequired, TypedDict, cast
 
 from .storage import commit_data, get_data_dir, read_json, write_json
 
 logger = logging.getLogger("planning-context")
+
+
+class ConversationEntry(TypedDict):
+    """A single agent-conversation summary within a day's record.
+
+    ``summary`` is the only field consumers in this codebase read.
+    ``started_at`` is bookkeeping the writer always emits but no
+    consumer touches — NotRequired so test fixtures and MCP-side
+    callers can construct entries without filler timestamps.
+    """
+
+    summary: str
+    started_at: NotRequired[str]
+
+
+class Conversation(TypedDict):
+    """A day's conversation file: date plus one or more summaries."""
+
+    date: str
+    entries: list[ConversationEntry]
 
 
 def _conversations_dir() -> Path:
@@ -23,14 +43,16 @@ def save_summary(summary: str) -> str:
     today_str = now.strftime("%Y-%m-%d")
     path = _conversations_dir() / f"{today_str}.json"
 
-    entry = {
+    entry: ConversationEntry = {
         "started_at": now.strftime("%Y-%m-%dT%H:%M:%S"),
         "summary": summary,
     }
 
+    data: Conversation
     if path.exists():
-        data = read_json(path)
-        if isinstance(data, dict) and "entries" in data:
+        existing = read_json(path)
+        if isinstance(existing, dict) and "entries" in existing:
+            data = cast(Conversation, existing)
             data["entries"].append(entry)
         else:
             logger.warning(
@@ -50,16 +72,16 @@ def save_summary(summary: str) -> str:
     return f"Conversation summary saved for {today_str}"
 
 
-def get_recent(count: int = 3) -> list[dict[str, Any]]:
+def get_recent(count: int = 3) -> list[Conversation]:
     """Return the most recent `count` conversation files, newest first."""
     conv_dir = _conversations_dir()
     if not conv_dir.exists():
         return []
 
     files = sorted(conv_dir.glob("*.json"), reverse=True)
-    results: list[dict[str, Any]] = []
+    results: list[Conversation] = []
     for f in files[:count]:
         data = read_json(f)
         if isinstance(data, dict):
-            results.append(data)
+            results.append(cast(Conversation, data))
     return results

--- a/src/planning_context/conversations.py
+++ b/src/planning_context/conversations.py
@@ -3,7 +3,7 @@
 import logging
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import NotRequired, TypedDict, cast
+from typing import Any, NotRequired, TypedDict, cast
 
 from .storage import commit_data, get_data_dir, read_json, write_json
 
@@ -72,8 +72,33 @@ def save_summary(summary: str) -> str:
     return f"Conversation summary saved for {today_str}"
 
 
+def _is_valid_conversation(data: object) -> bool:
+    """Shape-check a parsed conversation file.
+
+    The prompt renderer subscripts ``date``, ``entries``, and each
+    entry's ``summary`` directly. Any file missing those will crash
+    a downstream prompt build, so we filter at the read boundary
+    rather than defending in every consumer.
+    """
+    if not isinstance(data, dict):
+        return False
+    d = cast(dict[str, Any], data)
+    if "date" not in d or "entries" not in d:
+        return False
+    entries = d["entries"]
+    if not isinstance(entries, list):
+        return False
+    for entry in cast(list[Any], entries):
+        if not isinstance(entry, dict) or "summary" not in entry:
+            return False
+    return True
+
+
 def get_recent(count: int = 3) -> list[Conversation]:
-    """Return the most recent `count` conversation files, newest first."""
+    """Return the most recent `count` conversation files, newest first.
+
+    Files that fail shape validation are skipped and logged.
+    """
     conv_dir = _conversations_dir()
     if not conv_dir.exists():
         return []
@@ -82,6 +107,10 @@ def get_recent(count: int = 3) -> list[Conversation]:
     results: list[Conversation] = []
     for f in files[:count]:
         data = read_json(f)
-        if isinstance(data, dict):
+        if _is_valid_conversation(data):
             results.append(cast(Conversation, data))
+        else:
+            logger.warning(
+                "Skipping malformed conversation file %s", f.name
+            )
     return results

--- a/src/planning_context/memories.py
+++ b/src/planning_context/memories.py
@@ -3,7 +3,7 @@
 import logging
 from datetime import date, datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import NotRequired, TypedDict, cast
 
 from .storage import commit_data, get_data_dir, read_json, write_json
 
@@ -12,21 +12,43 @@ logger = logging.getLogger("planning-context")
 VALID_CATEGORIES = ("fact", "observation", "open_thread", "preference")
 
 
+class Memory(TypedDict):
+    """A persisted memory record.
+
+    ``id``, ``content``, and ``category`` are written by every code
+    path that produces a Memory and read directly by every consumer.
+    The remaining fields are bookkeeping the writer always emits but
+    most consumers don't touch — marked NotRequired so test fixtures
+    and partial-data code paths typecheck without filler values.
+    """
+
+    id: str
+    content: str
+    category: str
+    expiry_date: NotRequired[str | None]
+    confidence: NotRequired[str]
+    confirming_count: NotRequired[int]
+    source_date: NotRequired[str]
+    resolved: NotRequired[bool]
+    resolved_at: NotRequired[str | None]
+    created_at: NotRequired[str]
+
+
 def _memories_path() -> Path:
     return get_data_dir() / "memories.json"
 
 
-def _load_memories() -> list[dict[str, Any]]:
+def _load_memories() -> list[Memory]:
     data = read_json(_memories_path())
     assert isinstance(data, list)
-    return data  # type: ignore[return-value]
+    return cast(list[Memory], data)
 
 
-def _save_memories(memories: list[dict[str, Any]]) -> None:
+def _save_memories(memories: list[Memory]) -> None:
     write_json(_memories_path(), memories)
 
 
-def _next_id(memories: list[dict[str, Any]]) -> str:
+def _next_id(memories: list[Memory]) -> str:
     """Generate the next m_NNN id."""
     max_n = 0
     for m in memories:
@@ -41,11 +63,11 @@ def _next_id(memories: list[dict[str, Any]]) -> str:
     return f"m_{max_n + 1:03d}"
 
 
-def get_active() -> list[dict[str, Any]]:
+def get_active() -> list[Memory]:
     """Return all non-resolved, non-expired memories."""
     today = date.today().isoformat()
     memories = _load_memories()
-    active: list[dict[str, Any]] = []
+    active: list[Memory] = []
     for m in memories:
         if m.get("resolved"):
             continue
@@ -60,7 +82,7 @@ def add_memory(
     content: str,
     category: str,
     expiry_date: str | None = None,
-) -> dict[str, Any]:
+) -> Memory:
     """Add a new memory. Returns the created memory dict."""
     if category not in VALID_CATEGORIES:
         raise ValueError(
@@ -74,7 +96,7 @@ def add_memory(
     now = datetime.now(timezone.utc)
     confidence = "high" if category in ("fact", "preference") else "low"
 
-    memory = {
+    memory: Memory = {
         "id": _next_id(memories),
         "content": content,
         "category": category,
@@ -101,7 +123,7 @@ def add_memory(
     return memory
 
 
-def resolve_memory(memory_id: str) -> dict[str, Any] | None:
+def resolve_memory(memory_id: str) -> Memory | None:
     """Mark a memory as resolved. Returns the updated memory, or None if not found."""
     memories = _load_memories()
     for m in memories:

--- a/src/planning_context/memories.py
+++ b/src/planning_context/memories.py
@@ -63,12 +63,34 @@ def _next_id(memories: list[Memory]) -> str:
     return f"m_{max_n + 1:03d}"
 
 
+_REQUIRED_MEMORY_FIELDS = ("id", "content", "category")
+
+
 def get_active() -> list[Memory]:
-    """Return all non-resolved, non-expired memories."""
+    """Return all non-resolved, non-expired memories.
+
+    Skips and logs records missing any of the fields the prompt
+    renderer reads directly. Consumers can rely on the returned
+    ``Memory`` typing without per-field defensive access.
+    """
     today = date.today().isoformat()
     memories = _load_memories()
     active: list[Memory] = []
     for m in memories:
+        # _load_memories blanket-casts JSON to list[Memory]; the
+        # cast doesn't validate at runtime, so we still defend
+        # against corrupted/legacy on-disk records here.
+        if not isinstance(m, dict):  # pyright: ignore[reportUnnecessaryIsInstance]
+            logger.warning("Skipping malformed memory (not a dict): %r", m)
+            continue
+        missing = [f for f in _REQUIRED_MEMORY_FIELDS if f not in m]
+        if missing:
+            logger.warning(
+                "Skipping malformed memory missing %s: %r",
+                missing,
+                {k: m.get(k) for k in _REQUIRED_MEMORY_FIELDS},
+            )
+            continue
         if m.get("resolved"):
             continue
         expiry = m.get("expiry_date")

--- a/src/planning_context/server.py
+++ b/src/planning_context/server.py
@@ -94,9 +94,10 @@ async def get_active_memories() -> str:
     logger.debug("get_active_memories returning %d memories", len(active))
     lines: list[str] = []
     for m in active:
+        expiry = m.get("expiry_date")
         lines.append(
             f"[{m['id']}] ({m['category']}) {m['content']}"
-            + (f" [expires {m['expiry_date']}]" if m.get("expiry_date") else "")
+            + (f" [expires {expiry}]" if expiry else "")
         )
     return "\n".join(lines)
 

--- a/src/planning_context/storage.py
+++ b/src/planning_context/storage.py
@@ -4,6 +4,7 @@ import json
 import logging
 import os
 import subprocess
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
@@ -122,7 +123,9 @@ def read_json(path: Path) -> list[Any] | dict[str, Any]:
         return []
 
 
-def write_json(path: Path, data: list[Any] | dict[str, Any]) -> None:
+def write_json(
+    path: Path, data: Mapping[str, Any] | list[Any]
+) -> None:
     """Write data to a JSON file with pretty formatting."""
     try:
         path.write_text(

--- a/tests/test_conversations.py
+++ b/tests/test_conversations.py
@@ -75,3 +75,35 @@ def test_get_recent_respects_count(data_dir):
     assert len(get_recent(1)) == 1
     assert len(get_recent(3)) == 3
     assert len(get_recent(10)) == 4  # only 4 exist
+
+
+def test_get_recent_skips_malformed_files(data_dir, caplog):
+    from planning_context.conversations import get_recent
+    from planning_context.storage import get_data_dir, write_json
+
+    conv_dir = get_data_dir() / "conversations"
+    write_json(
+        conv_dir / "2026-02-20.json",
+        {"date": "2026-02-20", "entries": [{"summary": "Good"}]},
+    )
+    # Missing "entries"
+    write_json(
+        conv_dir / "2026-02-21.json",
+        {"date": "2026-02-21"},
+    )
+    # Entry missing "summary"
+    write_json(
+        conv_dir / "2026-02-22.json",
+        {
+            "date": "2026-02-22",
+            "entries": [{"started_at": "2026-02-22T10:00:00"}],
+        },
+    )
+
+    with caplog.at_level("WARNING", logger="planning-context"):
+        recent = get_recent(10)
+
+    assert len(recent) == 1
+    assert recent[0]["date"] == "2026-02-20"
+    assert "2026-02-21.json" in caplog.text
+    assert "2026-02-22.json" in caplog.text

--- a/tests/test_memories.py
+++ b/tests/test_memories.py
@@ -107,3 +107,35 @@ def test_invalid_expiry_raises(data_dir):
 
     with pytest.raises(ValueError):
         add_memory("Bad date", "fact", expiry_date="not-a-date")
+
+
+def test_get_active_skips_malformed_records(data_dir, caplog):
+    from planning_context.memories import get_active
+    from planning_context.storage import get_data_dir, write_json
+
+    write_json(
+        get_data_dir() / "memories.json",
+        [
+            # Good record
+            {
+                "id": "m_001",
+                "content": "Likes mornings",
+                "category": "preference",
+                "resolved": False,
+            },
+            # Missing "content"
+            {"id": "m_002", "category": "fact"},
+            # Missing "id"
+            {"content": "Orphan", "category": "observation"},
+            # Not even a dict
+            "totally bogus entry",
+        ],
+    )
+
+    with caplog.at_level("WARNING", logger="planning-context"):
+        active = get_active()
+
+    assert len(active) == 1
+    assert active[0]["id"] == "m_001"
+    # Each malformed entry produced a warning.
+    assert caplog.text.count("Skipping malformed memory") == 3

--- a/tests/test_planning_agent.py
+++ b/tests/test_planning_agent.py
@@ -24,9 +24,11 @@ from planning_agent.context import (
 )
 from planning_agent.extraction import (
     ExtractionResult,
-    Memory,
+    Memory as ExtractionMemory,
     _apply,
 )
+from planning_context.conversations import Conversation
+from planning_context.memories import Memory
 from tests.conftest import create_task
 
 
@@ -548,7 +550,7 @@ class TestExtractionResult:
     def test_full_result(self):
         result = ExtractionResult(
             new_memories=[
-                Memory(
+                ExtractionMemory(
                     content="Prefers mornings",
                     category="preference",
                 ),
@@ -575,11 +577,11 @@ class TestApplyExtraction:
     ):
         result = ExtractionResult(
             new_memories=[
-                Memory(
+                ExtractionMemory(
                     content="Likes hiking",
                     category="preference",
                 ),
-                Memory(
+                ExtractionMemory(
                     content="Dentist on March 20",
                     category="fact",
                     expiry_date="2026-03-20",
@@ -686,3 +688,165 @@ class TestAgentSystemPrompt:
         result = _format_conversations(convos)
         assert "2026-03-12" in result
         assert "Planned the week." in result
+
+
+def _make_ctx(
+    is_lazy: bool,
+    *,
+    todoist_snapshot: str = "FULL_TASKS_BODY",
+    calendar_snapshot: str = "FULL_CAL_BODY",
+    memories: list[Memory] | None = None,
+    conversations: list[Conversation] | None = None,
+    n_overdue: int = 0,
+    n_upcoming: int = 0,
+    n_memories: int = 0,
+    n_conversations: int = 0,
+) -> PlanningContext:
+    return PlanningContext(
+        is_lazy=is_lazy,
+        values_doc="MY_VALUES_DOC",
+        memories=memories or [],
+        recent_conversations=conversations or [],
+        todoist_snapshot=todoist_snapshot,
+        calendar_snapshot=calendar_snapshot,
+        current_datetime="Saturday, May 02, 2026 09:00 AM",
+        day_type="weekend",
+        inbox_project="Inbox project: Inbox (ID: 999)",
+        n_overdue=n_overdue,
+        n_upcoming=n_upcoming,
+        n_memories=n_memories,
+        n_conversations=n_conversations,
+    )
+
+
+class TestRenderSystemPrompt:
+    def test_full_mode_includes_snapshot_bodies(self):
+        from planning_agent.agent import (
+            STATIC_PROMPT,
+            _render_system_prompt,
+        )
+        ctx = _make_ctx(
+            is_lazy=False,
+            memories=[
+                {
+                    "id": "m_001",
+                    "content": "Likes mornings",
+                    "category": "preference",
+                },
+            ],
+            conversations=[
+                {
+                    "date": "2026-05-01",
+                    "entries": [
+                        {"summary": "Last session."},
+                    ],
+                },
+            ],
+        )
+        prompt = _render_system_prompt(ctx)
+
+        assert STATIC_PROMPT in prompt
+        assert "MY_VALUES_DOC" in prompt
+        assert "FULL_TASKS_BODY" in prompt
+        assert "FULL_CAL_BODY" in prompt
+        assert "Likes mornings" in prompt
+        assert "Last session." in prompt
+        assert "Tasks (overdue + next 14 days)" in prompt
+        assert "Calendar (next 14 days)" in prompt
+        # The lazy-block markdown header ("### Available context")
+        # only appears in lazy renders. The bare string "Available
+        # context (call tools to load)" is also referenced in the
+        # static prompt's Lazy Context Mode section, so we have to
+        # match the heading prefix specifically to distinguish.
+        assert "### Available context (call tools to load)" not in prompt
+
+    def test_lazy_mode_renders_shape_summary(self):
+        from planning_agent.agent import (
+            _render_system_prompt,
+        )
+        ctx = _make_ctx(
+            is_lazy=True,
+            n_overdue=27,
+            n_upcoming=18,
+            n_memories=6,
+            n_conversations=3,
+        )
+        prompt = _render_system_prompt(ctx)
+
+        assert "### Available context (call tools to load)" in prompt
+        assert "27 overdue, 18 in next 14 days" in prompt
+        assert "find_tasks / find_tasks_by_date" in prompt
+        assert "Calendar: not loaded — call get_calendar(days)" in prompt
+        assert "Memories: 6 active — call get_memories" in prompt
+        assert (
+            "Recent conversations: 3 available "
+            "— call get_recent_conversations"
+        ) in prompt
+
+    def test_lazy_mode_omits_full_snapshot_bodies(self):
+        from planning_agent.agent import (
+            _render_system_prompt,
+        )
+        ctx = _make_ctx(
+            is_lazy=True,
+            todoist_snapshot="SHOULD_NOT_APPEAR_TASKS",
+            calendar_snapshot="SHOULD_NOT_APPEAR_CAL",
+            memories=[
+                {
+                    "id": "m_999",
+                    "content": "SECRET_MEMORY_CONTENT",
+                    "category": "fact",
+                },
+            ],
+            conversations=[
+                {
+                    "date": "2026-05-01",
+                    "entries": [
+                        {"summary": "SECRET_CONV_SUMMARY"},
+                    ],
+                },
+            ],
+            n_memories=1,
+            n_conversations=1,
+        )
+        prompt = _render_system_prompt(ctx)
+
+        # Full bodies are not rendered — that's the whole point
+        # of lazy mode.
+        assert "SHOULD_NOT_APPEAR_TASKS" not in prompt
+        assert "SHOULD_NOT_APPEAR_CAL" not in prompt
+        assert "SECRET_MEMORY_CONTENT" not in prompt
+        assert "SECRET_CONV_SUMMARY" not in prompt
+        assert "Tasks (overdue + next 14 days)" not in prompt
+        assert "Calendar (next 14 days)" not in prompt
+        assert "Active memories" not in prompt
+
+    def test_always_shown_sections_present_in_both_modes(self):
+        from planning_agent.agent import (
+            _render_system_prompt,
+        )
+        for is_lazy in (False, True):
+            prompt = _render_system_prompt(_make_ctx(is_lazy))
+            # Values, inbox ID, current datetime, day type
+            # are cheap and live in the prompt regardless.
+            assert "MY_VALUES_DOC" in prompt, (
+                f"values missing in lazy={is_lazy}"
+            )
+            assert "Inbox project: Inbox (ID: 999)" in prompt, (
+                f"inbox missing in lazy={is_lazy}"
+            )
+            assert (
+                "Saturday, May 02, 2026 09:00 AM" in prompt
+            ), f"datetime missing in lazy={is_lazy}"
+            assert "weekend day" in prompt, (
+                f"day_type missing in lazy={is_lazy}"
+            )
+
+    def test_static_prompt_contains_lazy_context_section(self):
+        from planning_agent.agent import STATIC_PROMPT
+
+        assert "## Lazy Context Mode" in STATIC_PROMPT
+        # Names the fetch tools so the agent knows what to call.
+        assert "get_calendar(days)" in STATIC_PROMPT
+        assert "get_memories" in STATIC_PROMPT
+        assert "get_recent_conversations" in STATIC_PROMPT


### PR DESCRIPTION
closes #74

## What changed
- Adds a `## Lazy Context Mode` section to `STATIC_PROMPT` naming the on-demand fetch tools (`find_tasks` / `find_tasks_by_date`, `get_calendar`, `get_memories`, `get_recent_conversations`) and instructing the agent when to call them.
- Extracts the prompt body out of the `build_system_prompt` closure into a module-level `_render_system_prompt(deps)`. Branches on `deps.is_lazy`:
  - **Full**: byte-identical to the prior rendering.
  - **Lazy**: drops the task snapshot, calendar, memory list, and conversation list. Renders a shape-summary block with `n_overdue` / `n_upcoming` / `n_memories` / `n_conversations`. Always-shown sections (values doc, inbox project ID, current datetime, day type) appear in both modes.

## TypedDict refactor (scope expansion)
While typing the test helper, replaced `list[dict[str, Any]]` with proper TypedDicts:
- `planning_context.memories.Memory` — `id`/`content`/`category` required; writer-only bookkeeping fields (`confidence`, `confirming_count`, etc.) `NotRequired`.
- `planning_context.conversations.Conversation` and `ConversationEntry` — required fields are the ones every consumer reads; `started_at` is `NotRequired` because nothing reads it.
- Propagated through `PlanningContext`, `_format_memories`, `_format_conversations`, the MCP server's `get_active_memories`, and `write_json`'s signature (widened to `Mapping[str, Any] | list[Any]`).

## Tests
- New `TestRenderSystemPrompt` covering full-mode body, lazy-mode shape summary, lazy-mode omission of full bodies, always-shown sections in both modes, and `STATIC_PROMPT` containing the Lazy Context Mode section.
- Existing tests updated to use `ExtractionMemory` for the Pydantic Memory model where it now collides with the storage `Memory` TypedDict.

## Verification
- `uv run pytest` — 266 passed
- `uv run pyright` — 0 errors, 2 pre-existing missing-stub warnings for Google API clients

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Planning agent supports a "lazy context mode" that summarizes available context and indicates which tools to call to load tasks, calendar, memories, and conversations on demand.

* **Improvements**
  * System prompt updated with a dedicated Lazy Context Mode section and clearer rendering for full vs lazy modes.
  * Stronger typed models for memories and conversations to improve reliability.

* **Bug Fixes**
  * Runtime validation now skips and logs malformed memory or conversation records.

* **Tests**
  * Added tests covering lazy vs full prompt rendering and malformed record handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->