### PR TITLE
feat: add lazy-mode fetch tools (#75)

### DIFF
--- a/src/planning_agent/agent.py
+++ b/src/planning_agent/agent.py
@@ -45,10 +45,14 @@ async def _default_confirm(
         return False
     return answer in ("y", "yes")
 
-from planning_context.conversations import Conversation
+from planning_context.conversations import (
+    Conversation,
+    get_recent as _get_recent_conversations,
+)
 from planning_context.memories import (
     Memory,
     add_memory as _add_memory,
+    get_active as _get_active_memories,
     resolve_memory as _resolve_memory,
 )
 from planning_context.values import write_values
@@ -57,7 +61,7 @@ from todoist_mcp import tools as _tools
 from todoist_mcp.tools import RescheduleItem
 
 from .config import TODOIST_API_KEY, LLM_MODEL
-from .context import PlanningContext
+from .context import PlanningContext, fetch_calendar_snapshot
 
 # -- Static system prompt (adapted from system-prompt.md) --
 # The "Start of Conversation" section is removed because
@@ -684,6 +688,57 @@ def create_agent(
             f"({len(content)} chars)",
             write_values,
             content,
+        )
+
+    # ---------------------------------------------------------------
+    # Lazy-mode fetch tools
+    # ---------------------------------------------------------------
+    # Used when the system prompt is rendered in lazy mode and the
+    # agent needs to pull data that isn't pre-loaded. See the "Lazy
+    # Context Mode" section of STATIC_PROMPT for invocation rules.
+
+    @planning_agent.tool
+    async def get_calendar(  # pyright: ignore[reportUnusedFunction]
+        ctx: RunContext[PlanningContext],
+        days: int = 14,
+    ) -> str:
+        """Fetch upcoming Google Calendar events.
+
+        days: How far ahead to look (default 14).
+        """
+        return await _run_tool(
+            "get_calendar",
+            f"days={days}",
+            fetch_calendar_snapshot,
+            days,
+        )
+
+    @planning_agent.tool
+    async def get_memories(  # pyright: ignore[reportUnusedFunction]
+        ctx: RunContext[PlanningContext],
+    ) -> str:
+        """Fetch the full active-memory list."""
+        return await _run_tool(
+            "get_memories",
+            "",
+            lambda: _format_memories(_get_active_memories()),
+        )
+
+    @planning_agent.tool
+    async def get_recent_conversations(  # pyright: ignore[reportUnusedFunction]
+        ctx: RunContext[PlanningContext],
+        count: int = 3,
+    ) -> str:
+        """Fetch summaries of recent past conversations.
+
+        count: Number of recent days to include (default 3).
+        """
+        return await _run_tool(
+            "get_recent_conversations",
+            f"count={count}",
+            lambda: _format_conversations(
+                _get_recent_conversations(count)
+            ),
         )
 
     return planning_agent

--- a/src/planning_agent/context.py
+++ b/src/planning_agent/context.py
@@ -151,7 +151,7 @@ def _fetch_todoist_snapshot(
     return "\n".join(lines), n_overdue, n_upcoming
 
 
-def _fetch_calendar_snapshot(days: int = 14) -> str:
+def fetch_calendar_snapshot(days: int = 14) -> str:
     """Fetch next ``days`` days of Google Calendar events.
 
     Returns a formatted string of events, or a short
@@ -289,7 +289,7 @@ def build_context(lazy: bool = False) -> PlanningContext:
     if lazy:
         calendar_snapshot = LAZY_CALENDAR_PLACEHOLDER
     else:
-        calendar_snapshot = _fetch_calendar_snapshot()
+        calendar_snapshot = fetch_calendar_snapshot()
 
     now = datetime.now(ZoneInfo(USER_TZ))
     current_datetime = now.strftime("%A, %B %d, %Y %I:%M %p")

--- a/tests/test_planning_agent.py
+++ b/tests/test_planning_agent.py
@@ -16,7 +16,7 @@ from planning_agent.context import (
     LAZY_TODOIST_PLACEHOLDER,
     PlanningContext,
     _compute_day_type,
-    _fetch_calendar_snapshot,
+    fetch_calendar_snapshot,
     _fetch_inbox_project,
     _fetch_todoist_snapshot,
     _fmt_task,
@@ -216,7 +216,7 @@ class TestFetchCalendarSnapshot:
     @patch("planning_agent.context.GOOGLE_CALENDAR_CREDENTIALS")
     def test_no_credentials_returns_fallback(self, mock_path):
         mock_path.exists.return_value = False
-        result = _fetch_calendar_snapshot()
+        result = fetch_calendar_snapshot()
         assert result == "(Google Calendar not connected)"
 
     @patch("planning_agent.context._save_credentials")
@@ -252,7 +252,7 @@ class TestFetchCalendarSnapshot:
             ]
         }
 
-        result = _fetch_calendar_snapshot()
+        result = fetch_calendar_snapshot()
 
         assert "Next 14 days:" in result
         assert "Team meeting" in result
@@ -278,7 +278,7 @@ class TestFetchCalendarSnapshot:
             .execute.return_value
         ) = {"items": []}
 
-        result = _fetch_calendar_snapshot()
+        result = fetch_calendar_snapshot()
 
         assert result == "No calendar events in next 14 days."
 
@@ -292,7 +292,7 @@ class TestFetchCalendarSnapshot:
         self, mock_path, _mock_creds
     ):
         mock_path.exists.return_value = True
-        result = _fetch_calendar_snapshot()
+        result = fetch_calendar_snapshot()
         assert "(Google Calendar error:" in result
         assert "auth error" in result
 
@@ -316,7 +316,7 @@ class TestFetchCalendarSnapshot:
             .execute.side_effect
         ) = RefreshError("Token has been revoked")
 
-        result = _fetch_calendar_snapshot()
+        result = fetch_calendar_snapshot()
         assert result == CALENDAR_NEEDS_RECONNECT
 
     @patch("planning_agent.context._save_credentials")
@@ -341,7 +341,7 @@ class TestFetchCalendarSnapshot:
             .execute.return_value
         ) = {"items": []}
 
-        _fetch_calendar_snapshot()
+        fetch_calendar_snapshot()
         mock_save.assert_called_once_with(creds_obj)
 
 
@@ -434,7 +434,7 @@ class TestBuildContext:
         assert len(ctx.memories) == 1
         assert ctx.memories[0]["id"] == "m_001"
 
-    @patch("planning_agent.context._fetch_calendar_snapshot")
+    @patch("planning_agent.context.fetch_calendar_snapshot")
     @patch("planning_agent.context._fetch_inbox_project")
     @patch("planning_agent.context._fetch_todoist_snapshot")
     @patch(
@@ -529,7 +529,7 @@ class TestBuildContext:
             .execute.return_value
         ) = {"items": []}
 
-        result = _fetch_calendar_snapshot(days=7)
+        result = fetch_calendar_snapshot(days=7)
         assert result == "No calendar events in next 7 days."
 
 
@@ -850,3 +850,22 @@ class TestRenderSystemPrompt:
         assert "get_calendar(days)" in STATIC_PROMPT
         assert "get_memories" in STATIC_PROMPT
         assert "get_recent_conversations" in STATIC_PROMPT
+
+
+class TestLazyFetchTools:
+    @patch("planning_agent.agent.TODOIST_API_KEY", "fake-key")
+    def test_lazy_fetch_tools_registered(self):
+        # The lazy prompt names these three tools (#74); without
+        # them registered the agent would hit a wall when lazy
+        # mode kicks in. Probes the pydantic-ai internal toolset
+        # rather than firing the LLM.
+        from planning_agent.agent import create_agent
+
+        agent = create_agent()
+        tool_names = {
+            t.name
+            for t in agent._function_toolset.tools.values()  # pyright: ignore[reportPrivateUsage]
+        }
+        assert "get_calendar" in tool_names
+        assert "get_memories" in tool_names
+        assert "get_recent_conversations" in tool_names


### PR DESCRIPTION
closes #75

## What changed
Three new `@planning_agent.tool` functions in `agent.py` so lazy-mode sessions can pull data the prompt no longer pre-loads:

- `get_calendar(days: int = 14)` — wraps `fetch_calendar_snapshot(days)` from `context.py`.
- `get_memories()` — calls `planning_context.memories.get_active()` and formats with `_format_memories`.
- `get_recent_conversations(count: int = 3)` — calls `planning_context.conversations.get_recent(count)` and formats with `_format_conversations`.

All three are read-only (no `confirm` prompt) and route through `_run_tool` so debug tracing fires.

## Drive-by
- Promoted `_fetch_calendar_snapshot` to `fetch_calendar_snapshot`. The function is now legitimately part of `context.py`'s public surface (`agent.py` calls it as a tool implementation), and pyright was rightly flagging the cross-module private import.
- Updated all callers (`agent.py`, `context.py`'s `build_context`, the existing `tests/test_planning_agent.py` references).

## Test
- `TestLazyFetchTools.test_lazy_fetch_tools_registered` probes pydantic-ai's `_function_toolset.tools` and asserts the three new names appear. This is intentionally narrow — broader behavior coverage is #77's job.
- 269 tests pass, pyright clean.

## Not done in this PR
- Manual end-to-end smoke test against the live LLM ("what's on my calendar this week" → tool call). Can't be driven from a non-interactive environment; verify on deploy.
- Wiring `main_cli` / `main_web` to `lazy=True` is #76.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Planning agent can now access upcoming calendar events and recent conversation summaries when processing tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->