### PR TITLE
Enable lazy context for CLI and web entry points (#76)

### DIFF
--- a/src/planning_agent/main_cli.py
+++ b/src/planning_agent/main_cli.py
@@ -53,7 +53,7 @@ async def main() -> None:
     )
     logfire.instrument_pydantic_ai()
     console.print("Building context...")
-    ctx = build_context()
+    ctx = build_context(lazy=True)
 
     # Mutable holder so the confirm callback can
     # pause/resume the Live display during prompts.

--- a/src/planning_agent/main_web.py
+++ b/src/planning_agent/main_web.py
@@ -230,7 +230,7 @@ async def websocket_endpoint(ws: WebSocket) -> None:
 
     await ws.accept()
 
-    ctx = build_context()
+    ctx = build_context(lazy=True)
     history: list[Any] = []
 
     if ctx.calendar_snapshot == CALENDAR_NEEDS_RECONNECT:


### PR DESCRIPTION
closes #76

Two-line change: `main_cli.py` and `main_web.py` now call
`build_context(lazy=True)`. With the prompt branching (#74) and
fetch tools (#75) already merged, this is the flip-the-switch step
that turns lazy mode on for production interactive sessions.

`main_nightly.py` does not call `build_context`, so it keeps its
existing full-data behavior unchanged — matches the milestone
acceptance criterion that nightly stays full-context.

## Verification
- `uv run pyright`: 0 errors (only pre-existing missing-stub warnings)
- `uv run pytest`: 269 passed
- Live verification on deploy still pending (no LLM smoke from here)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal context initialization to use optimized loading for the planning agent in both command-line and web interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->