### PR TITLE
Advertise update_task in STATIC_PROMPT; add tool-coverage test (#71)

### DIFF
--- a/src/planning_agent/agent.py
+++ b/src/planning_agent/agent.py
@@ -183,6 +183,11 @@ relevant.
 - `reschedule_tasks(tasks)` — move tasks to new dates. \
 **Always use this for date changes** — preserves \
 recurring patterns and reminders.
+- `update_task(task_id, content, description, priority, \
+labels, project_id)` — edit title, description, \
+priority, or labels; set `project_id` to move the task \
+to a different project. **Never use for due dates — \
+use `reschedule_tasks` instead.**
 - `complete_task(task_id)` — mark done.
 - `delete_task(task_id)` — permanently delete a task.
 - `add_task(content, due_string, ...)` — create a task.

--- a/tests/test_prompt_coverage.py
+++ b/tests/test_prompt_coverage.py
@@ -50,7 +50,7 @@ def test_all_tools_advertised_or_listed() -> None:
         name
         for name in _registered_tool_names()
         if name not in INTENTIONALLY_UNADVERTISED
-        and name not in STATIC_PROMPT
+        and f"`{name}" not in STATIC_PROMPT
     ]
     assert not missing, (
         "These tools are registered but neither advertised in"

--- a/tests/test_prompt_coverage.py
+++ b/tests/test_prompt_coverage.py
@@ -1,0 +1,72 @@
+"""Every @mcp.tool / @server.tool must be named in STATIC_PROMPT
+or listed in INTENTIONALLY_UNADVERTISED with a written reason.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import planning_context.server as planning_server
+import todoist_mcp.server as todoist_server
+from planning_agent.agent import STATIC_PROMPT
+
+# Tools that exist but are intentionally not advertised to the agent.
+# Each entry documents why. Removing an entry without advertising the
+# tool in STATIC_PROMPT will fail test_all_tools_advertised_or_listed.
+INTENTIONALLY_UNADVERTISED: dict[str, str] = {
+    # planning_context — data pre-loaded into the prompt or handled
+    # by the post-session extractor, not called by the agent directly
+    "get_values_doc": (
+        "pre-loaded into the system prompt; agent reads it directly"
+    ),
+    "get_active_memories": (
+        "pre-loaded in full mode; lazy mode wraps it in the"
+        " get_memories agent tool"
+    ),
+    "save_conversation_summary": (
+        "called by the post-session extractor, not the agent"
+    ),
+    # todoist_mcp — registered but no current agent use case;
+    # promote to STATIC_PROMPT when a use case is identified
+    "get_sections": "no current agent use case",
+    "get_comments": "no current agent use case",
+    "get_overview": "summary view; agent uses find_tasks instead",
+    "add_project": "no current agent use case",
+    "add_section": "no current agent use case",
+    "add_comment": "no current agent use case",
+}
+
+
+def _registered_tool_names() -> list[str]:
+    async def _collect() -> list[str]:
+        todoist = await todoist_server.mcp.list_tools()
+        planning = await planning_server.server.list_tools()
+        return [t.name for t in todoist] + [t.name for t in planning]
+
+    return asyncio.run(_collect())
+
+
+def test_all_tools_advertised_or_listed() -> None:
+    missing = [
+        name
+        for name in _registered_tool_names()
+        if name not in INTENTIONALLY_UNADVERTISED
+        and name not in STATIC_PROMPT
+    ]
+    assert not missing, (
+        "These tools are registered but neither advertised in"
+        f" STATIC_PROMPT nor listed in INTENTIONALLY_UNADVERTISED:"
+        f" {missing}"
+    )
+
+
+def test_unadvertised_set_has_no_stale_entries() -> None:
+    registered = set(_registered_tool_names())
+    stale = [
+        name
+        for name in INTENTIONALLY_UNADVERTISED
+        if name not in registered
+    ]
+    assert not stale, (
+        "INTENTIONALLY_UNADVERTISED contains names that are no longer"
+        f" registered: {stale}. Remove them from the set."
+    )


### PR DESCRIPTION
closes #71

Adds `update_task` to the `### Modifying Tasks` section of `STATIC_PROMPT` so the agent knows it can move tasks between projects via `project_id`, and knows not to use it for due-date changes.

Adds `tests/test_prompt_coverage.py` with two drift-prevention tests:
- `test_all_tools_advertised_or_listed` — fails if any `@mcp.tool` / `@server.tool` registration is neither mentioned in `STATIC_PROMPT` nor listed in `INTENTIONALLY_UNADVERTISED`
- `test_unadvertised_set_has_no_stale_entries` — fails if the allowlist contains a tool name that no longer exists

276 tests pass, pyright clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved task scheduling behavior: due date changes are now enforced to use the correct rescheduling mechanism to prevent accidental date updates.

* **Tests**
  * Added coverage checks to ensure agent tool listings stay consistent with documented capabilities and that intentionally hidden tools remain accurate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->