### PR TITLE
Fix agent text rendering before/after tool calls (#72)

### DIFF
--- a/src/planning_agent/static/index.html
+++ b/src/planning_agent/static/index.html
@@ -439,6 +439,8 @@
         addBubble("agent", data.content);
         setInputEnabled(true);
       } else if (data.type === "confirm") {
+        streamBubble = null;
+        streamRaw = "";
         showConfirm(data.id, data.tool, data.detail || "");
       } else if (data.type === "error") {
         streamBubble = null;


### PR DESCRIPTION
closes #72

When a `confirm` message arrived mid-stream, the active bubble was never sealed — post-tool text chunks kept accumulating in the same bubble as pre-tool text. Added the same two-line seal (`streamBubble = null`, `streamRaw = ""`) that the `error` handler already uses.

Expected layout after fix:
```
[pre-tool text]
[confirm banner]
[post-tool text]
```

Frontend-only change. Live verification needed on deploy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed confirmation prompts being affected by residual streaming content from previous interactions, ensuring clean and distraction-free confirmation dialogs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->