### PR TITLE
Add continuous deployment to CI pipeline (#84)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,3 +24,19 @@ jobs:
       - run: uv run pyright
 
       - run: uv run pytest
+
+  deploy:
+    needs: test
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - run: |
+          flyctl deploy -a planning-agent \
+            --remote-only \
+            --build-arg GIT_COMMIT=${GITHUB_SHA:0:7}
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -38,6 +38,23 @@ flyctl secrets set \
 
 ## Deploy
 
+### Continuous deployment (automatic)
+
+Merging to `main` triggers CI, which runs tests and then deploys
+automatically via the `deploy` job in `.github/workflows/ci.yml`.
+
+Requires a `FLY_API_TOKEN` GitHub Actions secret. One-time setup:
+
+```bash
+# Create a deploy token scoped to the app
+flyctl tokens create deploy -a planning-agent
+```
+
+Add the output token as a repository secret named `FLY_API_TOKEN`
+under Settings → Secrets and variables → Actions.
+
+### Manual deploy
+
 ```bash
 flyctl deploy --build-arg GIT_COMMIT=$(git rev-parse --short HEAD)
 ```


### PR DESCRIPTION
closes #84

Adds a `deploy` job to `ci.yml` that runs after `test` passes, but only on pushes to `main` (not PRs). Uses `superfly/flyctl-actions` to install flyctl and deploys with `--remote-only` so the Actions runner doesn't need Docker. Short SHA is sliced from `GITHUB_SHA` to match the `/health` endpoint format.

**Before this merges:** create a deploy token and add it as a GitHub secret:
```bash
flyctl tokens create deploy -a planning-agent
# → add output as FLY_API_TOKEN in repo Settings → Secrets and variables → Actions
```

Documents this setup in DEPLOY.md under a new "Continuous deployment" section.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Automated deployment workflow configured to trigger on code pushes to main, following successful tests.
  * Deployment documentation updated with continuous deployment procedures and required GitHub Actions setup prerequisites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->