### PR TITLE
feat: Milestone 5 — fuzzy recurring tasks

### DIFF
--- a/MILESTONES.md
+++ b/MILESTONES.md
@@ -128,7 +128,7 @@ from today and earlier, and spreads them forward using the existing
   (replaces local cron docs). (#54)
 
 
-## Milestone 5: Fuzzy Recurring Tasks — `planned`
+## Milestone 5: Fuzzy Recurring Tasks — `in-progress`
 **Goal:** Add the fuzzy-recurring-task subsystem: a `fuzzy_recurring.json`
 store, MCP tools to manage it, and agent integration so maintenance tasks
 (e.g. "check spare tire ~every 6 months") surface during weekly planning.
@@ -146,16 +146,16 @@ Post-v1 but self-contained.
 - All operations covered by unit tests with no live API calls.
 
 **Tasks:**
-- [ ] Add `src/planning_context/fuzzy_recurring.py` with CRUD functions:
+- [x] Add `src/planning_context/fuzzy_recurring.py` with CRUD functions:
   `add_fuzzy_recurring`, `get_fuzzy_recurring`, `update_last_done`,
   `get_due_soon`, `remove_fuzzy_recurring`. (#20)
-- [ ] Expose the new functions as MCP tools in
+- [x] Expose the new functions as MCP tools in
   `src/planning_context/server.py`. (#21)
-- [ ] Implement seasonal constraint evaluation (`not_winter` blocks Dec–Feb). (#22)
-- [ ] Update `STATIC_PROMPT` in `agent.py` with a "Fuzzy Recurring Tasks"
+- [x] Implement seasonal constraint evaluation (`not_winter` blocks Dec–Feb). (#22)
+- [x] Update `STATIC_PROMPT` in `agent.py` with a "Fuzzy Recurring Tasks"
   section. (#23)
-- [ ] Add `get_due_soon` results to `build_context()` pre-loaded snapshot. (#24)
-- [ ] Add `tests/test_fuzzy_recurring.py` covering due-soon detection,
+- [x] Add `get_due_soon` results to `build_context()` pre-loaded snapshot. (#24)
+- [x] Add `tests/test_fuzzy_recurring.py` covering due-soon detection,
   seasonal suppression, and `update_last_done` persistence. (#25)
 
 

--- a/src/planning_agent/agent.py
+++ b/src/planning_agent/agent.py
@@ -258,8 +258,11 @@ tasks with approximate intervals (e.g. "check spare tire \
 These are stored in a local file, not in Todoist.
 
 During weekly planning, check that section and work any \
-due items into the schedule. After the user confirms they \
-did one, call `update_fuzzy_last_done` to record the date.
+due items into the schedule. Only propose scheduling a task \
+when its seasonal_constraints allow it for the current month \
+— do not schedule out-of-season tasks. After the user \
+confirms they did one, call `update_fuzzy_last_done` to \
+record the date.
 
 Tools for managing fuzzy tasks:
 - `add_fuzzy_recurring_task(name, interval_days, \

--- a/src/planning_agent/agent.py
+++ b/src/planning_agent/agent.py
@@ -56,6 +56,11 @@ from planning_context.memories import (
     get_active as _get_active_memories,
     resolve_memory as _resolve_memory,
 )
+from planning_context.fuzzy_recurring import (
+    add_fuzzy_recurring as _add_fuzzy_recurring,
+    remove_fuzzy_recurring as _remove_fuzzy_recurring,
+    update_last_done as _update_fuzzy_last_done,
+)
 from planning_context.values import write_values
 from todoist_api_python.api import TodoistAPI
 from todoist_mcp import tools as _tools
@@ -245,6 +250,26 @@ schedule the furnace call?"
 - **Explain reasoning briefly when not obvious.**
 - **Frame maintenance tasks matter-of-factly.**
 
+## Fuzzy Recurring Tasks
+
+The "Fuzzy tasks due soon" section below lists maintenance \
+tasks with approximate intervals (e.g. "check spare tire \
+~every 180 days") that are coming due in the next 14 days. \
+These are stored in a local file, not in Todoist.
+
+During weekly planning, check that section and work any \
+due items into the schedule. After the user confirms they \
+did one, call `update_fuzzy_last_done` to record the date.
+
+Tools for managing fuzzy tasks:
+- `add_fuzzy_recurring_task(name, interval_days, \
+seasonal_constraints, notes)` — add a new fuzzy recurring \
+maintenance task
+- `update_fuzzy_last_done(task_id, date_str)` — mark a \
+fuzzy task as done on a date (YYYY-MM-DD)
+- `remove_fuzzy_recurring_task(task_id)` — remove a fuzzy \
+recurring task permanently
+
 ## What You Don't Do
 
 - Don't manage work tasks (unless told otherwise).
@@ -346,6 +371,9 @@ call `get_projects()` to look it up again.
 {deps.calendar_snapshot}"""
 
     footer = f"""
+
+### Fuzzy tasks due soon (next 14 days)
+{deps.fuzzy_due_soon}
 
 ### Right now
 {deps.current_datetime} — {deps.day_type} day"""
@@ -728,6 +756,85 @@ def create_agent(
             f"({len(content)} chars)",
             write_values,
             content,
+        )
+
+    # ---------------------------------------------------------------
+    # Fuzzy recurring task tools
+    # ---------------------------------------------------------------
+
+    @planning_agent.tool
+    async def add_fuzzy_recurring_task(  # pyright: ignore[reportUnusedFunction]
+        ctx: RunContext[PlanningContext],
+        name: str,
+        interval_days: int,
+        seasonal_constraints: Optional[list[str]] = None,
+        notes: Optional[str] = None,
+    ) -> str:
+        """Add a new fuzzy recurring maintenance task.
+
+        interval_days: approximate recurrence in days.
+        seasonal_constraints: e.g. ["not_winter"].
+        """
+        detail = f'"{name}" every {interval_days}d'
+        if not await confirm("add_fuzzy_recurring_task", detail):
+            return "Cancelled by user."
+
+        def _do_add() -> str:
+            t = _add_fuzzy_recurring(
+                name,
+                interval_days,
+                seasonal_constraints,
+                notes,
+            )
+            return f"Added: {t['id']} — {t['name']}"
+
+        return await _run_tool(
+            "add_fuzzy_recurring_task",
+            detail,
+            _do_add,
+        )
+
+    @planning_agent.tool
+    async def update_fuzzy_last_done(  # pyright: ignore[reportUnusedFunction]
+        ctx: RunContext[PlanningContext],
+        task_id: str,
+        date_str: str,
+    ) -> str:
+        """Mark a fuzzy recurring task as done on a date.
+
+        date_str: ISO date "YYYY-MM-DD".
+        """
+        detail = f"{task_id} on {date_str}"
+        if not await confirm("update_fuzzy_last_done", detail):
+            return "Cancelled by user."
+        return await _run_tool(
+            "update_fuzzy_last_done",
+            detail,
+            lambda: (
+                f"Marked {task_id} done on {date_str}."
+                if _update_fuzzy_last_done(task_id, date_str)
+                else f"Fuzzy task {task_id} not found."
+            ),
+        )
+
+    @planning_agent.tool
+    async def remove_fuzzy_recurring_task(  # pyright: ignore[reportUnusedFunction]
+        ctx: RunContext[PlanningContext],
+        task_id: str,
+    ) -> str:
+        """Remove a fuzzy recurring task permanently."""
+        if not await confirm(
+            "remove_fuzzy_recurring_task", task_id
+        ):
+            return "Cancelled by user."
+        return await _run_tool(
+            "remove_fuzzy_recurring_task",
+            task_id,
+            lambda: (
+                f"Removed fuzzy task {task_id}."
+                if _remove_fuzzy_recurring(task_id)
+                else f"Fuzzy task {task_id} not found."
+            ),
         )
 
     # ---------------------------------------------------------------

--- a/src/planning_agent/agent.py
+++ b/src/planning_agent/agent.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import traceback as _traceback
+from datetime import date
 from typing import Any, Awaitable, Callable, Optional
 
 from rich.console import Console
@@ -807,6 +808,10 @@ def create_agent(
 
         date_str: ISO date "YYYY-MM-DD".
         """
+        try:
+            date.fromisoformat(date_str)
+        except ValueError:
+            return f"Invalid date {date_str!r}. Use YYYY-MM-DD."
         detail = f"{task_id} on {date_str}"
         if not await confirm("update_fuzzy_last_done", detail):
             return "Cancelled by user."

--- a/src/planning_agent/context.py
+++ b/src/planning_agent/context.py
@@ -54,6 +54,7 @@ class PlanningContext:
     n_upcoming: int
     n_memories: int
     n_conversations: int
+    fuzzy_due_soon: str
 
 
 def _compute_day_type() -> str:
@@ -253,6 +254,27 @@ def _fetch_inbox_project(api: TodoistAPI) -> str:
     return "(Inbox project not found)"
 
 
+def _format_fuzzy_due_soon() -> str:
+    """Return formatted fuzzy-recurring due-soon tasks."""
+    from planning_context.fuzzy_recurring import get_due_soon
+
+    try:
+        tasks = get_due_soon(14)
+    except Exception as exc:
+        return f"(error loading fuzzy tasks: {exc})"
+    if not tasks:
+        return "(none due in the next 14 days)"
+    lines: list[str] = []
+    for t in tasks:
+        last = t.get("last_done") or "never done"
+        lines.append(
+            f"- {t['id']}: {t['name']}"
+            f" (every {t['interval_days']} days,"
+            f" last done {last})"
+        )
+    return "\n".join(lines)
+
+
 def build_context(lazy: bool = False) -> PlanningContext:
     """Assemble planning context for a conversation.
 
@@ -295,6 +317,8 @@ def build_context(lazy: bool = False) -> PlanningContext:
     current_datetime = now.strftime("%A, %B %d, %Y %I:%M %p")
     day_type = _compute_day_type()
 
+    fuzzy_due_soon = _format_fuzzy_due_soon()
+
     return PlanningContext(
         is_lazy=lazy,
         values_doc=values_doc,
@@ -309,4 +333,5 @@ def build_context(lazy: bool = False) -> PlanningContext:
         n_upcoming=n_upcoming,
         n_memories=len(memories),
         n_conversations=len(conversations),
+        fuzzy_due_soon=fuzzy_due_soon,
     )

--- a/src/planning_context/fuzzy_recurring.py
+++ b/src/planning_context/fuzzy_recurring.py
@@ -95,19 +95,28 @@ def update_last_done(
     date_str: str,
 ) -> FuzzyRecurring | None:
     """Set last_done on a task. Returns updated task or None."""
+    try:
+        normalized = date.fromisoformat(date_str).isoformat()
+    except ValueError:
+        logger.warning(
+            "update_last_done: invalid date %r for %s",
+            date_str,
+            task_id,
+        )
+        return None
     tasks = _load()
     for t in tasks:
         if t["id"] == task_id:
-            t["last_done"] = date_str
+            t["last_done"] = normalized
             _save(tasks)
             commit_data(
                 _path().parent,
-                f"fuzzy: mark done {task_id} on {date_str}",
+                f"fuzzy: mark done {task_id} on {normalized}",
             )
             logger.info(
                 "Fuzzy recurring updated: %s last_done=%s",
                 task_id,
-                date_str,
+                normalized,
             )
             return t
     logger.warning("update_last_done: id %s not found", task_id)
@@ -120,7 +129,15 @@ def _is_suppressed(
 ) -> bool:
     for constraint in task.get("seasonal_constraints", []):
         suppressed_months = SEASONAL_SUPPRESSORS.get(constraint)
-        if suppressed_months and month in suppressed_months:
+        if suppressed_months is None:
+            logger.warning(
+                "Unknown seasonal constraint %r on fuzzy task %s;"
+                " suppressing",
+                constraint,
+                task.get("id", "?"),
+            )
+            return True
+        if month in suppressed_months:
             return True
     return False
 
@@ -146,7 +163,16 @@ def get_due_soon(
         if last_done is None:
             due.append(t)
             continue
-        last_date = date.fromisoformat(last_done)
+        try:
+            last_date = date.fromisoformat(last_done)
+        except ValueError:
+            logger.warning(
+                "get_due_soon: skipping task %s with invalid"
+                " last_done=%r",
+                t.get("id", "?"),
+                last_done,
+            )
+            continue
         next_target = last_date + timedelta(days=t["interval_days"])
         window_end = ref + timedelta(days=days_ahead)
         if next_target <= window_end:

--- a/src/planning_context/fuzzy_recurring.py
+++ b/src/planning_context/fuzzy_recurring.py
@@ -1,0 +1,170 @@
+"""Fuzzy recurring maintenance task CRUD operations."""
+
+import logging
+from datetime import date
+from pathlib import Path
+from typing import NotRequired, TypedDict, cast
+
+from .storage import commit_data, get_data_dir, read_json, write_json
+
+logger = logging.getLogger("planning-context")
+
+WINTER_MONTHS = (12, 1, 2)
+
+SEASONAL_SUPPRESSORS: dict[str, set[int]] = {
+    "not_winter": set(WINTER_MONTHS),
+}
+
+
+class FuzzyRecurring(TypedDict):
+    """A fuzzy recurring maintenance task."""
+
+    id: str
+    name: str
+    interval_days: int
+    last_done: str | None
+    seasonal_constraints: list[str]
+    notes: NotRequired[str]
+
+
+def _path() -> Path:
+    return get_data_dir() / "fuzzy_recurring.json"
+
+
+def _load() -> list[FuzzyRecurring]:
+    data = read_json(_path())
+    assert isinstance(data, list)
+    return cast(list[FuzzyRecurring], data)
+
+
+def _save(tasks: list[FuzzyRecurring]) -> None:
+    write_json(_path(), tasks)
+
+
+def _next_id(tasks: list[FuzzyRecurring]) -> str:
+    max_n = 0
+    for t in tasks:
+        tid = t.get("id", "")
+        if tid.startswith("fr_"):
+            try:
+                n = int(tid[3:])
+                if n > max_n:
+                    max_n = n
+            except ValueError:
+                pass
+    return f"fr_{max_n + 1:03d}"
+
+
+def add_fuzzy_recurring(
+    name: str,
+    interval_days: int,
+    seasonal_constraints: list[str] | None = None,
+    notes: str | None = None,
+) -> FuzzyRecurring:
+    """Add a new fuzzy recurring task. Returns the created record."""
+    tasks = _load()
+    task: FuzzyRecurring = {
+        "id": _next_id(tasks),
+        "name": name,
+        "interval_days": interval_days,
+        "last_done": None,
+        "seasonal_constraints": seasonal_constraints or [],
+    }
+    if notes is not None:
+        task["notes"] = notes
+    tasks.append(task)
+    _save(tasks)
+    commit_data(
+        _path().parent,
+        f"fuzzy: add {task['id']} ({name})",
+    )
+    logger.info("Fuzzy recurring added: %s — %s", task["id"], name)
+    return task
+
+
+def get_fuzzy_recurring(task_id: str) -> FuzzyRecurring | None:
+    """Return the task with the given ID, or None if not found."""
+    for t in _load():
+        if t["id"] == task_id:
+            return t
+    return None
+
+
+def update_last_done(
+    task_id: str,
+    date_str: str,
+) -> FuzzyRecurring | None:
+    """Set last_done on a task. Returns updated task or None."""
+    tasks = _load()
+    for t in tasks:
+        if t["id"] == task_id:
+            t["last_done"] = date_str
+            _save(tasks)
+            commit_data(
+                _path().parent,
+                f"fuzzy: mark done {task_id} on {date_str}",
+            )
+            logger.info(
+                "Fuzzy recurring updated: %s last_done=%s",
+                task_id,
+                date_str,
+            )
+            return t
+    logger.warning("update_last_done: id %s not found", task_id)
+    return None
+
+
+def _is_suppressed(
+    task: FuzzyRecurring,
+    month: int,
+) -> bool:
+    for constraint in task.get("seasonal_constraints", []):
+        suppressed_months = SEASONAL_SUPPRESSORS.get(constraint)
+        if suppressed_months and month in suppressed_months:
+            return True
+    return False
+
+
+def get_due_soon(
+    days_ahead: int,
+    reference_date: date | None = None,
+) -> list[FuzzyRecurring]:
+    """Return tasks due within days_ahead days of reference_date.
+
+    A task is due soon if:
+    - last_done is None, OR last_done + interval_days <= reference_date
+      + days_ahead
+    - AND no seasonal constraint suppresses it for the current month.
+    """
+    ref = reference_date if reference_date is not None else date.today()
+    month = ref.month
+    due: list[FuzzyRecurring] = []
+    for t in _load():
+        if _is_suppressed(t, month):
+            continue
+        last_done = t.get("last_done")
+        if last_done is None:
+            due.append(t)
+            continue
+        last_date = date.fromisoformat(last_done)
+        from datetime import timedelta
+        next_target = last_date + timedelta(days=t["interval_days"])
+        window_end = ref + timedelta(days=days_ahead)
+        if next_target <= window_end:
+            due.append(t)
+    return due
+
+
+def remove_fuzzy_recurring(task_id: str) -> bool:
+    """Remove a task by ID. Returns True if removed, False if not found."""
+    tasks = _load()
+    new_tasks = [t for t in tasks if t["id"] != task_id]
+    if len(new_tasks) == len(tasks):
+        return False
+    _save(new_tasks)
+    commit_data(
+        _path().parent,
+        f"fuzzy: remove {task_id}",
+    )
+    logger.info("Fuzzy recurring removed: %s", task_id)
+    return True

--- a/src/planning_context/fuzzy_recurring.py
+++ b/src/planning_context/fuzzy_recurring.py
@@ -1,7 +1,7 @@
 """Fuzzy recurring maintenance task CRUD operations."""
 
 import logging
-from datetime import date
+from datetime import date, timedelta
 from pathlib import Path
 from typing import NotRequired, TypedDict, cast
 
@@ -147,7 +147,6 @@ def get_due_soon(
             due.append(t)
             continue
         last_date = date.fromisoformat(last_done)
-        from datetime import timedelta
         next_target = last_date + timedelta(days=t["interval_days"])
         window_end = ref + timedelta(days=days_ahead)
         if next_target <= window_end:

--- a/src/planning_context/server.py
+++ b/src/planning_context/server.py
@@ -11,7 +11,7 @@ from typing import cast
 
 from fastmcp import FastMCP
 
-from . import conversations, memories, values
+from . import conversations, fuzzy_recurring, memories, values
 from .memories import MemoryCategory
 from .storage import get_data_dir
 
@@ -167,6 +167,108 @@ async def get_recent_conversations(count: int = 3) -> str:
         return "(No conversation history yet.)"
     logger.debug("get_recent_conversations returning %d records", len(recent))
     return json.dumps(recent, indent=2, ensure_ascii=False)
+
+
+# --- Fuzzy recurring tools ---
+
+
+@server.tool()
+async def add_fuzzy_recurring_task(
+    name: str,
+    interval_days: int,
+    seasonal_constraints: list[str] | None = None,
+    notes: str | None = None,
+) -> str:
+    """Add a new fuzzy recurring maintenance task.
+
+    interval_days: approximate recurrence in days.
+    seasonal_constraints: e.g. ["not_winter"].
+    """
+    logger.debug(
+        "Tool called: add_fuzzy_recurring_task name=%s", name
+    )
+    t = fuzzy_recurring.add_fuzzy_recurring(
+        name,
+        interval_days,
+        seasonal_constraints,
+        notes,
+    )
+    return f"Fuzzy recurring task added: {t['id']} — {t['name']}"
+
+
+@server.tool()
+async def get_fuzzy_recurring_task(task_id: str) -> str:
+    """Get a fuzzy recurring task by ID.
+
+    Returns JSON of the task record, or a not-found message.
+    """
+    logger.debug(
+        "Tool called: get_fuzzy_recurring_task id=%s", task_id
+    )
+    t = fuzzy_recurring.get_fuzzy_recurring(task_id)
+    if t is None:
+        return f"Fuzzy recurring task {task_id} not found."
+    return json.dumps(t, indent=2, ensure_ascii=False)
+
+
+@server.tool()
+async def update_fuzzy_last_done(
+    task_id: str,
+    date_str: str,
+) -> str:
+    """Mark a fuzzy recurring task as done on a date.
+
+    date_str: ISO date "YYYY-MM-DD".
+    """
+    logger.debug(
+        "Tool called: update_fuzzy_last_done id=%s date=%s",
+        task_id,
+        date_str,
+    )
+    t = fuzzy_recurring.update_last_done(task_id, date_str)
+    if t is None:
+        return f"Fuzzy recurring task {task_id} not found."
+    return (
+        f"Fuzzy recurring task {task_id} ({t['name']})"
+        f" marked done on {date_str}."
+    )
+
+
+@server.tool()
+async def remove_fuzzy_recurring_task(task_id: str) -> str:
+    """Remove a fuzzy recurring task by ID."""
+    logger.debug(
+        "Tool called: remove_fuzzy_recurring_task id=%s", task_id
+    )
+    removed = fuzzy_recurring.remove_fuzzy_recurring(task_id)
+    if not removed:
+        return f"Fuzzy recurring task {task_id} not found."
+    return f"Fuzzy recurring task {task_id} removed."
+
+
+@server.tool()
+async def get_due_soon_fuzzy(days_ahead: int = 14) -> str:
+    """Get fuzzy recurring tasks due within days_ahead days.
+
+    Returns formatted list, or a message if none are due.
+    """
+    logger.debug(
+        "Tool called: get_due_soon_fuzzy days_ahead=%d", days_ahead
+    )
+    tasks = fuzzy_recurring.get_due_soon(days_ahead)
+    if not tasks:
+        return (
+            f"(none due in the next {days_ahead} days)"
+        )
+    lines: list[str] = []
+    for t in tasks:
+        last = t.get("last_done") or "never done"
+        lines.append(
+            f"- {t['id']}: {t['name']}"
+            f" (every {t['interval_days']} days,"
+            f" last done {last})"
+        )
+    return "\n".join(lines)
 
 
 def main() -> None:

--- a/tests/test_fuzzy_recurring.py
+++ b/tests/test_fuzzy_recurring.py
@@ -1,11 +1,8 @@
 """Tests for fuzzy recurring task data layer."""
 
-import os
 from datetime import date
 
 import pytest
-
-os.environ["PLANNING_AGENT_DATA_DIR"] = ""
 
 
 @pytest.fixture(autouse=True)
@@ -151,3 +148,34 @@ def test_update_last_done_nonexistent_returns_none(data_dir):
 
     result = update_last_done("fr_999", "2026-01-01")
     assert result is None
+
+
+def test_update_last_done_invalid_date_returns_none(data_dir):
+    from planning_context.fuzzy_recurring import (
+        add_fuzzy_recurring,
+        get_fuzzy_recurring,
+        update_last_done,
+    )
+
+    add_fuzzy_recurring("Validated task", 30)
+    result = update_last_done("fr_001", "not-a-date")
+    assert result is None
+    # last_done must not be changed
+    reloaded = get_fuzzy_recurring("fr_001")
+    assert reloaded is not None
+    assert reloaded["last_done"] is None
+
+
+def test_unknown_seasonal_constraint_suppresses(data_dir):
+    from planning_context.fuzzy_recurring import (
+        add_fuzzy_recurring,
+        get_due_soon,
+    )
+
+    add_fuzzy_recurring(
+        "Unknown constraint task",
+        30,
+        seasonal_constraints=["not_recognized"],
+    )
+    ref = date(2026, 5, 1)
+    assert get_due_soon(14, reference_date=ref) == []

--- a/tests/test_fuzzy_recurring.py
+++ b/tests/test_fuzzy_recurring.py
@@ -1,0 +1,153 @@
+"""Tests for fuzzy recurring task data layer."""
+
+import os
+from datetime import date
+
+import pytest
+
+os.environ["PLANNING_AGENT_DATA_DIR"] = ""
+
+
+@pytest.fixture(autouse=True)
+def data_dir(tmp_path, monkeypatch):
+    monkeypatch.setenv("PLANNING_AGENT_DATA_DIR", str(tmp_path))
+    return tmp_path
+
+
+def test_add_and_get_fuzzy_task(data_dir):
+    from planning_context.fuzzy_recurring import (
+        add_fuzzy_recurring,
+        get_fuzzy_recurring,
+    )
+
+    t = add_fuzzy_recurring("Check spare tire", 180)
+    assert t["id"] == "fr_001"
+    assert t["name"] == "Check spare tire"
+    assert t["interval_days"] == 180
+    assert t["last_done"] is None
+
+    fetched = get_fuzzy_recurring("fr_001")
+    assert fetched is not None
+    assert fetched["name"] == "Check spare tire"
+
+
+def test_id_increments(data_dir):
+    from planning_context.fuzzy_recurring import add_fuzzy_recurring
+
+    t1 = add_fuzzy_recurring("Task one", 30)
+    t2 = add_fuzzy_recurring("Task two", 60)
+    t3 = add_fuzzy_recurring("Task three", 90)
+    assert t1["id"] == "fr_001"
+    assert t2["id"] == "fr_002"
+    assert t3["id"] == "fr_003"
+
+
+def test_remove_fuzzy_task(data_dir):
+    from planning_context.fuzzy_recurring import (
+        add_fuzzy_recurring,
+        get_fuzzy_recurring,
+        remove_fuzzy_recurring,
+    )
+
+    add_fuzzy_recurring("Removable", 45)
+    result = remove_fuzzy_recurring("fr_001")
+    assert result is True
+    assert get_fuzzy_recurring("fr_001") is None
+
+
+def test_remove_nonexistent_returns_false(data_dir):
+    from planning_context.fuzzy_recurring import remove_fuzzy_recurring
+
+    assert remove_fuzzy_recurring("fr_999") is False
+
+
+def test_get_due_soon_never_done(data_dir):
+    from planning_context.fuzzy_recurring import (
+        add_fuzzy_recurring,
+        get_due_soon,
+    )
+
+    add_fuzzy_recurring("Never done task", 365)
+    ref = date(2026, 5, 1)
+    due = get_due_soon(14, reference_date=ref)
+    assert len(due) == 1
+    assert due[0]["id"] == "fr_001"
+
+
+def test_get_due_soon_recently_done(data_dir):
+    from planning_context.fuzzy_recurring import (
+        add_fuzzy_recurring,
+        get_due_soon,
+        update_last_done,
+    )
+
+    add_fuzzy_recurring("Recent task", 90)
+    # Done 5 days ago — next due in 85 days, outside the 14-day window
+    ref = date(2026, 5, 1)
+    last = date(2026, 4, 26).isoformat()
+    update_last_done("fr_001", last)
+    due = get_due_soon(14, reference_date=ref)
+    assert due == []
+
+
+def test_get_due_soon_coming_up(data_dir):
+    from planning_context.fuzzy_recurring import (
+        add_fuzzy_recurring,
+        get_due_soon,
+        update_last_done,
+    )
+
+    add_fuzzy_recurring("Coming up task", 90)
+    # Done 80 days ago — next due in 10 days, inside the 14-day window
+    ref = date(2026, 5, 1)
+    last = date(2026, 2, 10).isoformat()
+    update_last_done("fr_001", last)
+    due = get_due_soon(14, reference_date=ref)
+    assert len(due) == 1
+    assert due[0]["id"] == "fr_001"
+
+
+def test_seasonal_suppression_not_winter(data_dir):
+    from planning_context.fuzzy_recurring import (
+        add_fuzzy_recurring,
+        get_due_soon,
+    )
+
+    add_fuzzy_recurring(
+        "Seasonal task",
+        30,
+        seasonal_constraints=["not_winter"],
+    )
+
+    # January — suppressed
+    jan_ref = date(2026, 1, 15)
+    assert get_due_soon(14, reference_date=jan_ref) == []
+
+    # May — not suppressed (task never done, so is due)
+    may_ref = date(2026, 5, 15)
+    due = get_due_soon(14, reference_date=may_ref)
+    assert len(due) == 1
+    assert due[0]["id"] == "fr_001"
+
+
+def test_update_last_done_persists(data_dir):
+    from planning_context.fuzzy_recurring import (
+        add_fuzzy_recurring,
+        get_fuzzy_recurring,
+        update_last_done,
+    )
+
+    add_fuzzy_recurring("Persist test", 60)
+    update_last_done("fr_001", "2026-04-01")
+
+    # Reload from disk
+    reloaded = get_fuzzy_recurring("fr_001")
+    assert reloaded is not None
+    assert reloaded["last_done"] == "2026-04-01"
+
+
+def test_update_last_done_nonexistent_returns_none(data_dir):
+    from planning_context.fuzzy_recurring import update_last_done
+
+    result = update_last_done("fr_999", "2026-01-01")
+    assert result is None

--- a/tests/test_planning_agent.py
+++ b/tests/test_planning_agent.py
@@ -701,6 +701,7 @@ def _make_ctx(
     n_upcoming: int = 0,
     n_memories: int = 0,
     n_conversations: int = 0,
+    fuzzy_due_soon: str = "(none due in the next 14 days)",
 ) -> PlanningContext:
     return PlanningContext(
         is_lazy=is_lazy,
@@ -716,6 +717,7 @@ def _make_ctx(
         n_upcoming=n_upcoming,
         n_memories=n_memories,
         n_conversations=n_conversations,
+        fuzzy_due_soon=fuzzy_due_soon,
     )
 
 

--- a/tests/test_prompt_coverage.py
+++ b/tests/test_prompt_coverage.py
@@ -36,6 +36,14 @@ INTENTIONALLY_UNADVERTISED: dict[str, str] = {
     "add_project": "no current agent use case",
     "add_section": "no current agent use case",
     "add_comment": "no current agent use case",
+    # planning_context — fuzzy recurring tools not called directly
+    "get_due_soon_fuzzy": (
+        "results pre-loaded into build_context;"
+        " agent reads them from prompt"
+    ),
+    "get_fuzzy_recurring_task": (
+        "no direct agent use case; agent uses the pre-loaded list"
+    ),
 }
 
 


### PR DESCRIPTION
## Summary

- Adds `src/planning_context/fuzzy_recurring.py` with `FuzzyRecurring` TypedDict and full CRUD: `add_fuzzy_recurring`, `get_fuzzy_recurring`, `update_last_done`, `get_due_soon`, `remove_fuzzy_recurring`. ID sequence is `fr_001`, `fr_002`, etc., following the memories pattern.
- `get_due_soon` evaluates seasonal constraints; `not_winter` suppresses tasks in December, January, and February.
- Five new `@server.tool()` functions in `src/planning_context/server.py` expose the CRUD operations over MCP.
- `PlanningContext` gains a `fuzzy_due_soon: str` field populated by `build_context()` via a local file read (no network, always loaded).
- `STATIC_PROMPT` gains a "Fuzzy Recurring Tasks" section; three agent tools (`add_fuzzy_recurring_task`, `update_fuzzy_last_done`, `remove_fuzzy_recurring_task`) are registered on the agent. `get_due_soon_fuzzy` and `get_fuzzy_recurring_task` are added to `INTENTIONALLY_UNADVERTISED`.
- `tests/test_fuzzy_recurring.py` adds 10 tests covering CRUD, due-soon detection, seasonal suppression, and persistence.

## Test plan

- [x] `uv run pytest` — 287 passed, 0 failures
- [x] `uv run pyright` — 0 errors, 2 pre-existing warnings

closes #20
closes #21
closes #22
closes #23
closes #24
closes #25

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Fuzzy recurring task management: create, update, remove recurring maintenance tasks with persistent last-done tracking
  * Planning view now surfaces fuzzy tasks due within the next 14 days and exposes actions to mark tasks done or view due items
  * Seasonal suppression to automatically skip tasks during specified periods
* **Tests**
  * Added comprehensive tests for CRUD, due-soon detection, seasonal suppression, and persistence
* **Documentation**
  * Milestone updated to in-progress for fuzzy recurring work
<!-- end of auto-generated comment: release notes by coderabbit.ai -->