### PR TITLE
perf: lazy-load fuzzy recurring tasks in interactive mode

### DIFF
--- a/MILESTONES.md
+++ b/MILESTONES.md
@@ -128,7 +128,7 @@ from today and earlier, and spreads them forward using the existing
   (replaces local cron docs). (#54)
 
 
-## Milestone 5: Fuzzy Recurring Tasks — `planned`
+## Milestone 5: Fuzzy Recurring Tasks — `in-progress`
 **Goal:** Add the fuzzy-recurring-task subsystem: a `fuzzy_recurring.json`
 store, MCP tools to manage it, and agent integration so maintenance tasks
 (e.g. "check spare tire ~every 6 months") surface during weekly planning.

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,26 +1,19 @@
 # Status
 
-**Last updated:** 2026-05-03 (session 14)
-**Active milestone:** Milestone 6 — Interactive Cost Reduction & Cleanup
+**Last updated:** 2026-05-03 (session 15)
+**Active milestone:** Milestone 5 — Fuzzy Recurring Tasks
 
 ## Recently Completed
 
-- **README rewrite** (session 14). Replaced the outdated "three
-  components that will be unified" framing with an accurate description
-  of the deployed system: web UI, all entry points, setup, deployment
-  flow, and conventions. Removed stale cron/Task Scheduler docs.
-- **#90 merged** (PR #91, session 14). Reverse prompt-coverage test:
-  asserts every tool named in `STATIC_PROMPT` (backtick+open-paren
-  pattern) is registered on the agent. Also added `()` to the
-  `get_memories` reference in `STATIC_PROMPT` for consistency. All
-  53 tests pass.
+- **M5 implemented** (session 15, PR #92 open). Fuzzy recurring task
+  subsystem: `fuzzy_recurring.py` CRUD, 5 MCP tools, `not_winter`
+  seasonal suppression, `fuzzy_due_soon` field in `PlanningContext`,
+  STATIC_PROMPT section, 10 tests. 287 tests pass. Awaiting merge.
+- **README rewrite** (session 14). Replaced the outdated framing with
+  an accurate description of the deployed system.
+- **#90 merged** (PR #91, session 14). Reverse prompt-coverage test.
 - **Full M6 live verification** (session 13). Lazy mode confirmed
-  working in production. Reschedule write, bubble fix, and
-  `update_task` / move-between-projects all verified.
-- **#80 merged** (PR #89). `MemoryCategory = Literal[...]`.
-- **#84 merged** (PR #87). CI auto-deploy to Fly.io on merge to main.
-- **#72 / update_task fix** (session 13). Bubble sealing for read-only
-  tools; `update_task` agent tool implemented.
+  working in production.
 
 ## In Progress
 
@@ -28,10 +21,13 @@ Nothing actively in progress.
 
 ## Next Up
 
-1. **#57** — Redeploy Fly cron Machine with bearer token as a Fly
-   secret (DECISIONS.md). Nightly job is still disabled. Last
-   remaining open M6 task.
-2. **Resume Milestone 5** — Fuzzy Recurring Tasks once M6 lands.
+1. **Merge PR #92** — M5 fuzzy recurring tasks. Ready to merge; all
+   tests pass, review complete.
+2. **#57** — Redeploy Fly cron Machine with bearer token as a Fly
+   secret (DECISIONS.md). Nightly job is still disabled. Last remaining
+   open M6 task.
+3. **M7** — Scheduling Pattern Learning (next planned milestone after
+   M5 and M6 land).
 
 ## Blockers / Open Questions
 
@@ -59,8 +55,10 @@ Nothing actively in progress.
 - Logfire tracing active in prod. Dashboard at
   logfire-us.pydantic.dev/pankok/planning-agent.
 - Branching strategy: per-issue branches for substantive work; direct
-  main pushes for small hotfixes (used several times this session).
-  PRs use `--merge --delete-branch`, never squash.
+  main pushes for small hotfixes. PRs use `--merge --delete-branch`,
+  never squash.
 - Anthropic prompt caching is on (`agent.py`, `anthropic_cache_instructions
   =True`, `anthropic_cache_messages=True`). Lazy mode (active in prod)
   targets short single-turn sessions that don't benefit from caching.
+- M5 (fuzzy recurring) was started before M6's last task (#57) by
+  user choice. M6 remains `in-progress` until #57 lands.

--- a/src/planning_agent/agent.py
+++ b/src/planning_agent/agent.py
@@ -229,6 +229,8 @@ question needs before answering:
 days you need.
 - Memories: `get_memories()` — full active memory list.
 - Recent conversations: `get_recent_conversations(count)`.
+- Fuzzy maintenance tasks: `get_fuzzy_due_soon(days)` — \
+pass the planning window.
 
 Don't fetch what the question doesn't need. A quick \
 "what's on today?" needs today's tasks and today's \
@@ -252,26 +254,15 @@ schedule the furnace call?"
 
 ## Fuzzy Recurring Tasks
 
-The "Fuzzy tasks due soon" section below lists maintenance \
-tasks with approximate intervals (e.g. "check spare tire \
-~every 180 days") that are coming due in the next 14 days. \
-These are stored in a local file, not in Todoist.
-
-During weekly planning, check that section and work any \
-due items into the schedule. Only propose scheduling a task \
-when its seasonal_constraints allow it for the current month \
-— do not schedule out-of-season tasks. After the user \
-confirms they did one, call `update_fuzzy_last_done` to \
-record the date.
-
-Tools for managing fuzzy tasks:
-- `add_fuzzy_recurring_task(name, interval_days, \
-seasonal_constraints, notes)` — add a new fuzzy recurring \
-maintenance task
-- `update_fuzzy_last_done(task_id, date_str)` — mark a \
-fuzzy task as done on a date (YYYY-MM-DD)
-- `remove_fuzzy_recurring_task(task_id)` — remove a fuzzy \
-recurring task permanently
+Maintenance tasks with approximate intervals (e.g. "check \
+spare tire ~every 180 days") live in a local file, not in \
+Todoist. During weekly planning, call `get_fuzzy_due_soon()` \
+to see what's coming due in the next 14 days; respect any \
+seasonal constraints. After a confirmed completion, call \
+`update_fuzzy_last_done(task_id, date_str)`. Add new ones \
+with `add_fuzzy_recurring_task(name, interval_days, \
+seasonal_constraints, notes)` and remove with \
+`remove_fuzzy_recurring_task(task_id)`.
 
 ## What You Don't Do
 
@@ -351,7 +342,8 @@ call `get_projects()` to look it up again.
 - Tasks: {deps.n_overdue} overdue, {deps.n_upcoming} in next 14 days — call find_tasks / find_tasks_by_date
 - Calendar: not loaded — call get_calendar(days)
 - Memories: {deps.n_memories} active — call get_memories
-- Recent conversations: {deps.n_conversations} available — call get_recent_conversations"""
+- Recent conversations: {deps.n_conversations} available — call get_recent_conversations
+- Fuzzy tasks: {deps.n_fuzzy_due} due in next 14 days — call get_fuzzy_due_soon"""
     else:
         middle = f"""
 
@@ -373,10 +365,15 @@ call `get_projects()` to look it up again.
 ### Calendar (next 14 days)
 {deps.calendar_snapshot}"""
 
-    footer = f"""
+    if deps.is_lazy:
+        fuzzy_block = ""
+    else:
+        fuzzy_block = (
+            "\n\n### Fuzzy tasks due soon (next 14 days)"
+            f"\n{deps.fuzzy_due_soon}"
+        )
 
-### Fuzzy tasks due soon (next 14 days)
-{deps.fuzzy_due_soon}
+    footer = f"""{fuzzy_block}
 
 ### Right now
 {deps.current_datetime} — {deps.day_type} day"""
@@ -889,6 +886,27 @@ def create_agent(
             lambda: _format_conversations(
                 _get_recent_conversations(count)
             ),
+        )
+
+    @planning_agent.tool
+    async def get_fuzzy_due_soon(  # pyright: ignore[reportUnusedFunction]
+        ctx: RunContext[PlanningContext],
+        days: int = 14,
+    ) -> str:
+        """Fetch fuzzy maintenance tasks due within ``days``.
+
+        Respects seasonal constraints (e.g. ``not_winter``).
+        """
+        from .context import fetch_fuzzy_due_soon
+
+        def _fetch() -> str:
+            snapshot, _ = fetch_fuzzy_due_soon(days)
+            return snapshot
+
+        return await _run_tool(
+            "get_fuzzy_due_soon",
+            f"days={days}",
+            _fetch,
         )
 
     return planning_agent

--- a/src/planning_agent/context.py
+++ b/src/planning_agent/context.py
@@ -35,6 +35,9 @@ LAZY_TODOIST_PLACEHOLDER = (
 LAZY_CALENDAR_PLACEHOLDER = (
     "(not loaded — call get_calendar)"
 )
+LAZY_FUZZY_PLACEHOLDER = (
+    "(not loaded — call get_fuzzy_due_soon)"
+)
 
 
 @dataclass
@@ -55,6 +58,7 @@ class PlanningContext:
     n_memories: int
     n_conversations: int
     fuzzy_due_soon: str
+    n_fuzzy_due: int
 
 
 def _compute_day_type() -> str:
@@ -254,16 +258,19 @@ def _fetch_inbox_project(api: TodoistAPI) -> str:
     return "(Inbox project not found)"
 
 
-def _format_fuzzy_due_soon() -> str:
-    """Return formatted fuzzy-recurring due-soon tasks."""
+def fetch_fuzzy_due_soon(days: int = 14) -> tuple[str, int]:
+    """Return (formatted snapshot, count) of fuzzy due-soon tasks.
+
+    Lazy mode uses only the count; full mode renders the snapshot.
+    """
     from planning_context.fuzzy_recurring import get_due_soon
 
     try:
-        tasks = get_due_soon(14)
+        tasks = get_due_soon(days)
     except Exception as exc:
-        return f"(error loading fuzzy tasks: {exc})"
+        return f"(error loading fuzzy tasks: {exc})", 0
     if not tasks:
-        return "(none due in the next 14 days)"
+        return f"(none due in the next {days} days)", 0
     lines: list[str] = []
     for t in tasks:
         last = t.get("last_done") or "never done"
@@ -272,7 +279,7 @@ def _format_fuzzy_due_soon() -> str:
             f" (every {t['interval_days']} days,"
             f" last done {last})"
         )
-    return "\n".join(lines)
+    return "\n".join(lines), len(tasks)
 
 
 def build_context(lazy: bool = False) -> PlanningContext:
@@ -317,7 +324,11 @@ def build_context(lazy: bool = False) -> PlanningContext:
     current_datetime = now.strftime("%A, %B %d, %Y %I:%M %p")
     day_type = _compute_day_type()
 
-    fuzzy_due_soon = _format_fuzzy_due_soon()
+    fuzzy_snapshot, n_fuzzy_due = fetch_fuzzy_due_soon()
+    if lazy:
+        fuzzy_due_soon = LAZY_FUZZY_PLACEHOLDER
+    else:
+        fuzzy_due_soon = fuzzy_snapshot
 
     return PlanningContext(
         is_lazy=lazy,
@@ -334,4 +345,5 @@ def build_context(lazy: bool = False) -> PlanningContext:
         n_memories=len(memories),
         n_conversations=len(conversations),
         fuzzy_due_soon=fuzzy_due_soon,
+        n_fuzzy_due=n_fuzzy_due,
     )

--- a/tests/test_planning_agent.py
+++ b/tests/test_planning_agent.py
@@ -702,6 +702,7 @@ def _make_ctx(
     n_memories: int = 0,
     n_conversations: int = 0,
     fuzzy_due_soon: str = "(none due in the next 14 days)",
+    n_fuzzy_due: int = 0,
 ) -> PlanningContext:
     return PlanningContext(
         is_lazy=is_lazy,
@@ -718,6 +719,7 @@ def _make_ctx(
         n_memories=n_memories,
         n_conversations=n_conversations,
         fuzzy_due_soon=fuzzy_due_soon,
+        n_fuzzy_due=n_fuzzy_due,
     )
 
 

--- a/tests/test_prompt_coverage.py
+++ b/tests/test_prompt_coverage.py
@@ -38,8 +38,7 @@ INTENTIONALLY_UNADVERTISED: dict[str, str] = {
     "add_comment": "no current agent use case",
     # planning_context — fuzzy recurring tools not called directly
     "get_due_soon_fuzzy": (
-        "results pre-loaded into build_context;"
-        " agent reads them from prompt"
+        "lazy mode wraps it in the get_fuzzy_due_soon agent tool"
     ),
     "get_fuzzy_recurring_task": (
         "no direct agent use case; agent uses the pre-loaded list"


### PR DESCRIPTION
## Summary

Stacks on top of #92. As designed there, every interactive turn pays for the fuzzy subsystem unconditionally — both the formatted snapshot and a ~20-line `## Fuzzy Recurring Tasks` rules block in `STATIC_PROMPT`. During dormant stretches (e.g. winter, when `not_winter` constraints suppress outdoor maintenance for three months) those tokens buy nothing.

This change wires fuzzy into the existing M6 lazy-context pattern alongside calendar / memories / recent conversations, and condenses the always-on rules block to a 7-line breadcrumb.

- `context.py`: add `LAZY_FUZZY_PLACEHOLDER` and `n_fuzzy_due` field; rename `_format_fuzzy_due_soon` → `fetch_fuzzy_due_soon` (now used cross-module), return `(snapshot, count)`, accept `days` arg
- `agent.py`: register `get_fuzzy_due_soon` agent fetch tool mirroring `get_calendar`; gate the formatted footer block on full mode only; add fuzzy to the Lazy Context Mode list and the lazy "Available context" bullet list
- `test_prompt_coverage.py`: update `INTENTIONALLY_UNADVERTISED` reason for `get_due_soon_fuzzy` (MCP tool now wrapped by the agent-native tool, mirroring memories)
- `test_planning_agent.py`: thread `n_fuzzy_due` through the `_make_ctx` helper

Production today only ever calls `build_context(lazy=True)` (`main_cli.py:56`, `main_web.py:234`); full mode is exercised only by tests, and its rendering is preserved.

## Net per-turn effect (lazy mode)

- **N = 0** (dormant): no rules block, no footer section. One bullet: `Fuzzy tasks: 0 due — call get_fuzzy_due_soon`.
- **N > 0**: same one-bullet placeholder; agent calls `get_fuzzy_due_soon` during weekly planning to fetch the formatted list.

Discoverability preserved via the always-on 7-line `## Fuzzy Recurring Tasks` breadcrumb that names all four agent tools.

## Test plan

- [x] `uv run pytest` — 289 passed
- [x] `uv run pyright` — 0 errors, 2 pre-existing warnings
- [x] Manual prompt-render check: lazy/0, lazy/N, full/N all render as expected

## Merge order

Land #92 first; this PR will auto-retarget to `main`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HyVDzCCVishrT1rBF4a5RA)_