### PR TITLE
Refuse to reschedule P1 tasks at the tool layer (#97)

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -136,6 +136,33 @@ data source is rate-limited. Only skip the fetch outright when
 the cost of fetching outweighs the prompt-design value of having
 exact shape numbers.
 
+## P1 tasks are never auto-rescheduled (#97)
+
+**Decision:** `reschedule_task` raises `PriorityProtectedError`
+when called on a Todoist priority-4 (P1) task, before any API
+mutation. The Todoist MCP `reschedule_tasks` tool surfaces the
+refusal to the agent in its per-task results line.
+
+**Rationale:** Discovered 2026-05-24. A P1 weekly-recurring task
+was overdue from the previous Friday. The user asked the Sunday
+agent to move it to today. Todoist silently snapped the recurrence
+forward to next Friday (the pattern anchor), at which point the
+read-after-write defense (#62) correctly raised
+`DueDateMismatchError` — but the call should not have been
+attempted at all. Original `todoist_scheduler` already had the
+"never touch P1" rule at the fetch-filter layer
+(`overdue & ! p1` in `overdue.py`); the redesign's Sunday/Today
+agents bypass that filter by reading the snapshot directly and
+calling `reschedule_task` themselves. Putting the guard in the
+tool layer means policy survives any future change to context
+assembly or prompts.
+
+**How to apply:** To move a P1 task, the user downgrades the
+priority first or does it manually. The agent should explain
+this to the user when the refusal comes back. Do not add an
+override flag — leaving a P1 overdue is the user's signal to do
+it now (Todoist sorts overdue items to the top of the Today view).
+
 ## XSS defense-in-depth in static chat UIs
 
 **Decision:** Both `static/index.html` and `static/today.html`

--- a/src/todoist_scheduler/reschedule.py
+++ b/src/todoist_scheduler/reschedule.py
@@ -140,6 +140,25 @@ class DueDateMismatchError(Exception):
     """
 
 
+class PriorityProtectedError(Exception):
+    """Refused to reschedule a P1 (highest priority) task.
+
+    P1 tasks are never auto-rescheduled — leaving them overdue is
+    the user's signal to do them now. To move a P1, downgrade the
+    priority first or move it manually. See #97.
+    """
+
+    def __init__(self, task_id: str, task_content: str) -> None:
+        self.task_id = task_id
+        self.task_content = task_content
+        super().__init__(
+            f"Refusing to reschedule P1 task "
+            f"'{task_content}' ({task_id}): P1 tasks are not "
+            f"auto-rescheduled. Downgrade priority or move "
+            f"manually."
+        )
+
+
 class ReminderRestoreError(Exception):
     """Date update succeeded but reminders could not be restored.
 
@@ -217,6 +236,10 @@ def reschedule_task(
     time: str | None = None,
 ) -> None:
     """Reschedule a task to a new date via the Todoist API."""
+    # Todoist API priority: 1=p4 (lowest) ... 4=p1 (highest).
+    # Policy: P1 tasks are never auto-rescheduled. See #97.
+    if task.priority == 4:
+        raise PriorityProtectedError(task.id, task.content)
     due_string = compute_due_string(task, day, time)
     if due_string is None:
         return

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -94,7 +94,7 @@ class TestScheduling(unittest.TestCase):
 
     def test_schedule_fit_in_one_day(self):
         tasks_to_add = [
-            create_task('1', 'Task 1', priority=4, due_date_str='2023-12-31'),
+            create_task('1', 'Task 1', priority=3, due_date_str='2023-12-31'),
             create_task('2', 'Task 2', priority=1, due_date_str='2023-12-30')
         ]
         self.api.filter_tasks.return_value = iter([])
@@ -112,8 +112,8 @@ class TestScheduling(unittest.TestCase):
 
     def test_push_to_next_day(self):
         tasks_to_add = [
-            create_task('1', 'Task 1 P4', priority=4, due_date_str='2023-12-31'),
-            create_task('2', 'Task 2 P4', priority=4, due_date_str='2023-12-30'),
+            create_task('1', 'Task 1 P4', priority=3, due_date_str='2023-12-31'),
+            create_task('2', 'Task 2 P4', priority=3, due_date_str='2023-12-30'),
             create_task('3', 'Task 3 P1', priority=1, due_date_str='2023-12-29')
         ]
         self.api.filter_tasks.side_effect = [
@@ -133,8 +133,8 @@ class TestScheduling(unittest.TestCase):
         # by a higher-priority task.
         existing_task = create_task('existing', 'Existing Task', priority=1, due_date_str=self.today.strftime('%Y-%m-%d'))
         tasks_to_add = [
-            create_task('1', 'New Task 1 P4', priority=4, due_date_str='2023-12-31'),
-            create_task('2', 'New Task 2 P4', priority=4, due_date_str='2023-12-30')
+            create_task('1', 'New Task 1 P4', priority=3, due_date_str='2023-12-31'),
+            create_task('2', 'New Task 2 P4', priority=3, due_date_str='2023-12-30')
         ]
         self.api.filter_tasks.side_effect = [
             iter([[existing_task]]), iter([]),
@@ -157,7 +157,7 @@ class TestScheduling(unittest.TestCase):
             create_task(
                 '1',
                 'Task with time',
-                priority=4,
+                priority=3,
                 due_date_str='2023-12-31',
                 is_recurring=True,
                 due_string='every week at 5pm',
@@ -182,7 +182,7 @@ class TestScheduling(unittest.TestCase):
             create_task(
                 '1',
                 'Task with time',
-                priority=4,
+                priority=3,
                 due_date_str='2023-12-31',
                 is_recurring=False,
                 due_datetime_str=due_datetime_str

--- a/tests/test_reschedule.py
+++ b/tests/test_reschedule.py
@@ -7,6 +7,7 @@ from todoist_api_python.models import Duration
 
 from todoist_scheduler.reschedule import (
     DueDateMismatchError,
+    PriorityProtectedError,
     ReminderRestoreError,
     _strip_recurrence_pattern,
     _verify_due_date_matches,
@@ -851,6 +852,60 @@ class TestReminderRestoreError(unittest.TestCase):
         self.assertIn("2024-01-15", msg)
         self.assertIn("2", msg)
         self.assertIn("sync API down", msg)
+
+
+class TestPriorityProtected(unittest.TestCase):
+    """P1 (priority == 4) tasks must never be auto-rescheduled."""
+
+    def setUp(self):
+        self.api = MagicMock()
+        self.api._token = "tok"
+        self.api.update_task.return_value = True
+
+    @patch("todoist_scheduler.reschedule.fetch_reminders")
+    def test_p1_task_raises(self, mock_fetch):
+        task = create_task(
+            '1', 'Important', priority=4,
+            due_date_str='2024-01-10',
+        )
+        with self.assertRaises(PriorityProtectedError):
+            reschedule_task(self.api, task, date(2024, 1, 15))
+        self.api.update_task.assert_not_called()
+        mock_fetch.assert_not_called()
+
+    @patch("todoist_scheduler.reschedule.fetch_reminders")
+    def test_p1_raises_even_when_already_on_day(self, mock_fetch):
+        # Guard fires before the no-op check — policy is "don't
+        # touch", not "don't change date".
+        task = create_task(
+            '1', 'Important', priority=4,
+            due_date_str='2024-01-15',
+        )
+        with self.assertRaises(PriorityProtectedError):
+            reschedule_task(self.api, task, date(2024, 1, 15))
+        self.api.update_task.assert_not_called()
+        mock_fetch.assert_not_called()
+
+    @patch("todoist_scheduler.reschedule.fetch_reminders")
+    def test_p2_task_proceeds(self, mock_fetch):
+        mock_fetch.return_value = []
+        self.api.get_task.return_value = create_task(
+            '1', 'Task', priority=3,
+            due_date_str='2024-01-15',
+        )
+        task = create_task(
+            '1', 'Task', priority=3,
+            due_date_str='2024-01-10',
+        )
+        reschedule_task(self.api, task, date(2024, 1, 15))
+        self.api.update_task.assert_called_once()
+
+    def test_error_message_names_task(self):
+        err = PriorityProtectedError('abc', 'Check finances')
+        msg = str(err)
+        self.assertIn('Check finances', msg)
+        self.assertIn('abc', msg)
+        self.assertIn('P1', msg)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
closes #97

## Summary

- `reschedule_task` now raises `PriorityProtectedError` on any task
  with Todoist priority == 4 (P1) before any API call.
- MCP `reschedule_tasks` surfaces the refusal via its existing
  per-task `✗ <id>: <error>` formatting — no change needed.
- Nightly job unaffected (it pre-filters P1 in `overdue.py`).
- `DECISIONS.md` records the policy and the 2026-05-24 incident.
- Fixed pre-existing `tests/test_basic.py` fixtures that used
  `priority=4` with names like "Task 1 P4" (Todoist encoding
  was inverted — priority=4 is P1, not P4). Switched the affected
  fixtures to `priority=3` to preserve their scheduler-ordering
  intent under the new guard. `TestSorting` tests left alone —
  they intentionally use P1 values to test sort behavior.

## Test plan

- [x] `uv run pytest` — 372 passed (4 new in `TestPriorityProtected`,
  was 368 before this branch).
- [x] `uv run pyright` — 0 errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added protection for high-priority (P1) Todoist tasks to prevent automatic rescheduling.

* **Bug Fixes**
  * Fixed uncontrolled auto-rescheduling of P1 tasks; users must now manually downgrade priority or move tasks.

* **Documentation**
  * Documented priority protection policy and user guidance for handling protected tasks.

* **Tests**
  * Added test coverage for priority protection behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kpanko/planning-agent/pull/98?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->