### PR TITLE
fix: strip bare time-of-day from recurrence patterns on reschedule (#99)

### DIFF
--- a/src/todoist_scheduler/reschedule.py
+++ b/src/todoist_scheduler/reschedule.py
@@ -23,12 +23,17 @@ def _parse_task_date(task: Task) -> date | None:
     return date.fromisoformat(date_str)
 
 
-# Strips a trailing `at <time>` clause from a Todoist recurrence
-# pattern. Matches "at 5pm", "at 5:30pm", "at 17:00", "at 9am",
-# case-insensitive. See #62 — we re-attach time before
-# `starting on` so Todoist honors the new weekday.
-_AT_TIME_RE = re.compile(
-    r"\s+at\s+\d{1,2}(?::\d{2})?\s*(?:am|pm)?\b",
+# Strips a time-of-day clause from a Todoist recurrence pattern,
+# with or without a leading "at". Matches "at 5pm", "at 5:30pm",
+# "at 17:00", "at 9am", and the bare forms "4 pm", "4pm", "16:00",
+# "12:30pm" — case-insensitive. The token must carry a colon or an
+# am/pm marker, so a bare cadence integer (the "3" in "every 3
+# days") is never mistaken for a time. See #62 (we re-attach time
+# before `starting on` so Todoist honors the new weekday) and the
+# bare-time double-time 400 this also guards against.
+_TIME_RE = re.compile(
+    r"\s+(?:at\s+)?"
+    r"(?:\d{1,2}:\d{2}(?:\s*(?:am|pm))?|\d{1,2}\s*(?:am|pm))\b",
     re.IGNORECASE,
 )
 
@@ -36,11 +41,12 @@ _AT_TIME_RE = re.compile(
 def _strip_recurrence_pattern(due_string: str) -> str:
     """Reduce a recurring due_string to just the cadence pattern.
 
-    Removes any trailing `starting on ...` clause and any `at <time>`
-    clause so we can re-emit the pattern with our own time placement.
+    Removes any trailing `starting on ...` clause and any time-of-day
+    clause (an explicit `at <time>` or a bare `4 pm` / `16:00`) so we
+    can re-emit the pattern with our own time placement.
     """
     pattern = re.sub(r'\s*starting on.*', '', due_string)
-    pattern = _AT_TIME_RE.sub('', pattern)
+    pattern = _TIME_RE.sub('', pattern)
     return pattern.strip()
 
 

--- a/tests/test_reschedule.py
+++ b/tests/test_reschedule.py
@@ -183,6 +183,43 @@ class TestComputeDueString(unittest.TestCase):
         )
         self.assertEqual(result, '2024-01-15 09:30')
 
+    def test_time_override_recurring_bare_time_pattern(self):
+        # A recurrence whose pattern embeds a bare time ("every
+        # day 4 pm", no "at") must not produce a double-time
+        # due_string like "every day 4 pm at 09:30 ...", which
+        # Todoist rejects with a 400.
+        task = create_task(
+            '1', 'Task',
+            due_date_str='2024-01-10',
+            is_recurring=True,
+            due_string='every day 4 pm',
+            due_datetime_str='2024-01-10T16:00:00Z',
+        )
+        result = compute_due_string(
+            task, date(2024, 1, 15), time='09:30',
+        )
+        self.assertEqual(
+            result,
+            'every day at 09:30 starting on 2024-01-15',
+        )
+
+    def test_recurring_bare_time_pattern_inherited_time(self):
+        # Plain date move (no override) reuses the existing time
+        # but must still strip the bare time in the pattern, or we
+        # emit "every day 4 pm at 16:00 ..." and Todoist 400s.
+        task = create_task(
+            '1', 'Task',
+            due_date_str='2024-01-10',
+            is_recurring=True,
+            due_string='every day 4 pm',
+            due_datetime_str='2024-01-10T16:00:00Z',
+        )
+        result = compute_due_string(task, date(2024, 1, 15))
+        self.assertEqual(
+            result,
+            'every day at 16:00 starting on 2024-01-15',
+        )
+
 
 class TestValidateRecurringPreserved(unittest.TestCase):
 
@@ -669,6 +706,38 @@ class TestStripRecurrencePattern(unittest.TestCase):
         self.assertEqual(
             _strip_recurrence_pattern('every Monday'),
             'every Monday',
+        )
+
+    def test_strips_bare_pm_time(self):
+        self.assertEqual(
+            _strip_recurrence_pattern('every day 4 pm'),
+            'every day',
+        )
+
+    def test_strips_bare_pm_no_space(self):
+        self.assertEqual(
+            _strip_recurrence_pattern('every day 4pm'),
+            'every day',
+        )
+
+    def test_strips_bare_24h_time(self):
+        self.assertEqual(
+            _strip_recurrence_pattern('every day 16:00'),
+            'every day',
+        )
+
+    def test_strips_bare_colon_ampm_time(self):
+        self.assertEqual(
+            _strip_recurrence_pattern('every day 12:30pm'),
+            'every day',
+        )
+
+    def test_keeps_interval_integer(self):
+        # The "3" is the cadence interval, not a time-of-day, so
+        # it must survive. Only colon/am-pm tokens are times.
+        self.assertEqual(
+            _strip_recurrence_pattern('every 3 days'),
+            'every 3 days',
         )
 
 


### PR DESCRIPTION
@
Fixes #99.

## Problem
Rescheduling a recurring task whose due string embeds a **bare** time
(no `at`) — e.g. `every day 4 pm` — produced a double-time due_string and
Todoist rejected it with `400 Bad Request`:

```
every day 4 pm at 15:00 starting on 2026-05-25
```

This hit both the time-override path and a plain date move (the inherited
time was re-appended on top of the un-stripped one).

## Fix
`_strip_recurrence_pattern` now removes a bare time token (with or without
`at`). To avoid mangling cadence integers, the token must carry a colon or
an am/pm marker, so the `3` in `every 3 days` is never treated as a time.

## Verification
- `uv run pytest` — 379 passed; `uv run pyright` — 0 errors.
- New unit tests: bare `4 pm` / `4pm` / `16:00` / `12:30pm` are stripped;
  `every 3 days` is preserved; `compute_due_string` emits a single-time
  string on both the override and inherited-time paths.
- Live (test project): the malformed string reproduces the exact 400; the
  fixed code emits `every day at 15:00 starting on 2026-05-25`, which
  Todoist accepts with recurrence preserved.

Related: #62, #66.
@

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of recurring task scheduling to properly recognize and normalize various time-of-day formats (e.g., "4 pm", "16:00") embedded in recurring task definitions, enabling accurate scheduler-controlled time placement.

* **Tests**
  * Added unit tests to verify correct handling of recurring tasks with embedded time patterns.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kpanko/planning-agent/pull/100?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->